### PR TITLE
Replace log analytics workspace which is GONE

### DIFF
--- a/src/SponsorLink/Constants.cs
+++ b/src/SponsorLink/Constants.cs
@@ -15,5 +15,5 @@ public static class Constants
     /// <summary>
     /// The log analytics workspace to use for querying.
     /// </summary>
-    public const string LogAnalyticsWorkspaceId = "b5823173-1be6-4d23-92e6-4d2a4a89ad20";
+    public const string LogAnalyticsWorkspaceId = "7f38af71-fab9-4d5c-9a32-743ed17c2d1a";
 }


### PR DESCRIPTION
Delete entire Azure log analytics workspace that was the only place with traces of the HTTP web requests performed to the Azure storage blobs with the email SHA256.

![image](https://github.com/devlooped/SponsorLink/assets/169707/d38516f1-b02c-42fa-8bef-775ec79ca673)

Fixes https://github.com/moq/moq/issues/1395. 

Verified by badge unavailable (which queries the [old deleted workspace](https://github.com/devlooped/SponsorLink/blob/main/src/App/Stats.cs#L45-L47) prior to this PR):  https://img.shields.io/endpoint.svg?url=https://sponsorlink.devlooped.com/stats/projects&label=total%20projects&color=blue

The original workspace ID can be verified as deleted by someone on the Azure team, I suppose. It used to be `b5823173-1be6-4d23-92e6-4d2a4a89ad20` if anyone from there can confirm externally. 

The way the blob storage requests made it into the analytics workspace was through a diagnostic settings in the storage account that forwarded storage events to the workspace. That was deleted prior to deleting the workspace:

![image](https://github.com/devlooped/SponsorLink/assets/169707/77f9d940-faf3-433b-9578-61e9ef1b6e6f)
