### PR TITLE
Create remove endpoint to improve compliance with GDPR

### DIFF
--- a/src/App/App.csproj
+++ b/src/App/App.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Auth0.AuthenticationApi" Version="7.22.2" />
+    <PackageReference Include="Auth0.ManagementApi" Version="7.22.2" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Azure.Core" Version="1.34.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.2.0" />

--- a/src/App/Security.cs
+++ b/src/App/Security.cs
@@ -7,14 +7,14 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Devlooped.SponsorLink;
 
-static class Auth0
+static class Security
 {
     static readonly IConfigurationManager<OpenIdConnectConfiguration> configuration;
 
     static readonly string Issuer = "https://sponsorlink.us.auth0.com/";
     static readonly string Audience = "https://sponsorlink.devlooped.com";
 
-    static Auth0()
+    static Security()
     {
         var documentRetriever = new HttpDocumentRetriever { RequireHttps = true };
 


### PR DESCRIPTION
This endpoint uses the Auth0 management API to entirely remove the authenticated user from their side.

Fixes #61