### PR TITLE
Unify /me as the endpoint for sponsor manifests

### DIFF
--- a/src/Web/SponsorLink.Legacy.cs
+++ b/src/Web/SponsorLink.Legacy.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+
+partial class SponsorLink
+{
+    /// <summary>
+    /// Backwards compatibility for pre-beta endpoint.
+    /// </summary>
+    [Function("sync")]
+    public IActionResult LegacySyncAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "sync")] HttpRequest req)
+        => new RedirectResult("me", true, true);
+}

--- a/src/Web/Version.cs
+++ b/src/Web/Version.cs
@@ -26,8 +26,7 @@ class Version(IConfiguration configuration, SponsorsManager sponsors, RSA rsa, I
         var json = jwt.Payload.SerializeToJson();
         var doc = JsonDocument.Parse(json);
 
-        var pubKey = Convert.ToBase64String(rsa.ExportRSAPublicKey());
-        if (pubKey != manifest.PublicKey)
+        if (!rsa.ThumbprintEquals(manifest.SecurityKey))
         {
             logger.LogError($"Configured private key 'SponsorLink:{nameof(SponsorLinkOptions.PrivateKey)}' does not match the manifest public key.");
             return new StatusCodeResult(500);
@@ -55,39 +54,6 @@ class Version(IConfiguration configuration, SponsorsManager sponsors, RSA rsa, I
         return new ContentResult
         {
             Content = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3),
-            ContentType = "text/plain",
-            StatusCode = 200,
-        };
-    }
-
-    [Function("pub")]
-    public IActionResult GetPublicKey([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req)
-    {
-        if (options.PublicKey is not { Length: > 0 } key)
-        {
-            logger.LogError($"Missing required configuration 'SponsorLink:{nameof(SponsorLinkOptions.PublicKey)}'");
-            return new StatusCodeResult(500);
-        }
-
-        if (req.GetTypedHeaders().Accept?.Any(x =>
-                x.MediaType == "application/json" ||
-                x.MediaType == "application/jwk+json") == true)
-        {
-            var rsa = RSA.Create();
-            rsa.ImportRSAPublicKey(Convert.FromBase64String(key), out _);
-            return new ContentResult
-            {
-                Content = JsonSerializer.Serialize(
-                    JsonWebKeyConverter.ConvertFromRSASecurityKey(new RsaSecurityKey(rsa.ExportParameters(false))),
-                    JsonOptions.JsonWebKey),
-                ContentType = "application/jwk+json",
-                StatusCode = 200,
-            };
-        }
-
-        return new ContentResult
-        {
-            Content = key,
             ContentType = "text/plain",
             StatusCode = 200,
         };


### PR DESCRIPTION
Makes more sense than `DELETE /sync` to do `GET /me` and `DELETE /me`.

Also renamed the now older `/me` as `/user` since it's more user-facing and mostly just for troubleshooting.

Removed the `/pub` endpoint which isn't used at all.