### PR TITLE
Remove base64-encoded public key from all APIs

### DIFF
--- a/src/Commands/InitCommand.cs
+++ b/src/Commands/InitCommand.cs
@@ -115,7 +115,7 @@ public partial class InitCommand : AsyncCommand<InitCommand.Settings>
 
         var manifest = new SponsorableManifest(new Uri(settings.Issuer),
             settings.Audience,
-            settings.ClientId, new RsaSecurityKey(rsa), pub64);
+            settings.ClientId, new RsaSecurityKey(rsa));
 
         // Serialize the token and return as a string
         var jwt = manifest.ToJwt();

--- a/src/Core/SponsorLinkOptions.cs
+++ b/src/Core/SponsorLinkOptions.cs
@@ -3,8 +3,6 @@
 /// <summary>
 /// Configured options for the sponsorable account set up with SponsorLink.
 /// </summary>
-/// <param name="Account">The sponsorable account using SponsorLink.</param>
-/// <param name="PublicKey">The RSA public key used to verify SponsorLink manifests.</param>
 public class SponsorLinkOptions
 {
     /// <summary>
@@ -12,12 +10,6 @@ public class SponsorLinkOptions
     /// of the bearer key used to authenticate with the GitHub API.
     /// </summary>
     public string? Account { get; set; }
-
-    /// <summary>
-    /// Optional public key to verify SponsorLink manifests. Defaults 
-    /// to the one in the JWT manifest of the sponsorable account .github repository.
-    /// </summary>
-    public string? PublicKey { get; set; }
 
     /// <summary>
     /// Optional private key to sign SponsorLink manifests.

--- a/src/Core/SponsorManifest.cs
+++ b/src/Core/SponsorManifest.cs
@@ -38,7 +38,7 @@ public class SponsorManifest
     {
         using var http = new HttpClient();
 
-        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(new Uri(manifest.Issuer), "sync"));
+        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(new Uri(manifest.Issuer), "me"));
         request.Headers.Authorization = new("Bearer", accessToken);
         request.Headers.Accept.Add(new("application/jwt"));
         var response = await http.SendAsync(request);

--- a/src/Core/SponsorsManager.cs
+++ b/src/Core/SponsorsManager.cs
@@ -14,8 +14,8 @@ public partial class SponsorsManager(
     IGraphQueryClientFactory graphFactory,
     IMemoryCache cache, ILogger<SponsorsManager> logger)
 {
-    const string JwtCacheKey = nameof(SponsorsManager) + ".JWT";
-    const string ManifestCacheKey = nameof(SponsorsManager) + ".Manifest";
+    internal const string JwtCacheKey = nameof(SponsorsManager) + ".JWT";
+    internal const string ManifestCacheKey = nameof(SponsorsManager) + ".Manifest";
 
     static readonly Serializer serializer = new();
     SponsorLinkOptions options = options.Value;
@@ -52,10 +52,6 @@ public partial class SponsorsManager(
             // Manifest audience should match the sponsorable account to avoid weird issues?
             if (account.Login != manifest.Sponsorable)
                 throw new InvalidOperationException("Manifest sponsorable account does not match configured sponsorable account.");
-
-            logger.Assert(options.PublicKey == manifest.PublicKey,
-                "Configured public key '{option}' does not match the manifest public key.",
-                $"SponsorLink:{nameof(SponsorLinkOptions.PublicKey)}");
 
             jwt = cache.Set(JwtCacheKey, jwt, new MemoryCacheEntryOptions
             {

--- a/src/Tests/SponsorManagerTests.cs
+++ b/src/Tests/SponsorManagerTests.cs
@@ -160,8 +160,9 @@ public class SponsorManagerTests : IDisposable
         await Authenticate();
 
         var cache = services.GetRequiredService<IMemoryCache>();
-        cache.Set(typeof(SponsorableManifest),
-            SponsorableManifest.Create(new Uri("https://sl.amazon.com"), [new Uri("https://github.com/aws")], "ASDF1324"));
+        var manifest = SponsorableManifest.Create(new Uri("https://sl.amazon.com"), [new Uri("https://github.com/aws")], "ASDF1324");
+        cache.Set(SponsorsManager.ManifestCacheKey, manifest);
+        cache.Set(SponsorsManager.JwtCacheKey, manifest.ToJwt());
 
         var sponsorable = services.GetRequiredService<IGraphQueryClientFactory>().CreateClient("sponsorable");
         var sponsor = services.GetRequiredService<IGraphQueryClientFactory>().CreateClient("sponsor");
@@ -242,7 +243,7 @@ public class SponsorManagerTests : IDisposable
         Assert.NotNull(claims);
         Assert.Contains(claims, claim => claim.Type == "roles" && claim.Value == "org");
 
-        var manifest = SponsorableManifest.Create(new Uri("https://sponsorlink.devlooped.com"), [new Uri("https://github.com/devlooped")], "ASDF1234");
+        var manifest = SponsorableManifest.Create(new Uri("https://sponsorlink.devlooped.com"), [new Uri("https://github.com/devlooped")], claims.First(c => c.Type == "client_id").Value);
 
         var jwt = manifest.Sign(claims);
 

--- a/src/Tests/SponsorableManifestTests.cs
+++ b/src/Tests/SponsorableManifestTests.cs
@@ -30,7 +30,6 @@ public class SponsorableManifestTests
         Assert.Contains(principal.Claims, x => x.Type == "iss" && x.Issuer == "https://foo.com/");
         Assert.Contains(principal.Claims, x => x.Type == "aud" && x.Value == "https://github.com/sponsors/bar");
         Assert.Contains(principal.Claims, x => x.Type == "client_id" && x.Value == "ASDF1234");
-        Assert.Contains(principal.Claims, x => x.Type == "pub" && x.Value == manifest.PublicKey);
         Assert.Contains(principal.Claims, x => x.Type == "sub_jwk");
 
         var jwk = JsonWebKey.Create(principal.Claims.First(x => x.Type == "sub_jwk").Value);
@@ -42,9 +41,7 @@ public class SponsorableManifestTests
     {
         var rsa = RSA.Create(3072);
         var key = new RsaSecurityKey(rsa);
-        var pub = Convert.ToBase64String(rsa.ExportRSAPublicKey());
-
-        var manifest = new SponsorableManifest(new Uri("https://foo.com"), [new Uri("https://github.com/sponsors/bar")], "ASDF1234", key, pub);
+        var manifest = new SponsorableManifest(new Uri("https://foo.com"), [new Uri("https://github.com/sponsors/bar")], "ASDF1234", key);
 
         var jwt = manifest.ToJwt(new SigningCredentials(key, SecurityAlgorithms.RsaSha256));
 


### PR DESCRIPTION
Just unify everything to JWK and thumbprint-based checks for consistency.