### PR TITLE
Add remove command to CLI

### DIFF
--- a/src/Cli/Properties/launchSettings.json
+++ b/src/Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Cli": {
       "commandName": "Project",
-      "commandLineArgs": "sync -i http://localhost:4242"
+      "commandLineArgs": "remove devlooped"
     }
   }
 }

--- a/src/Commands/App.cs
+++ b/src/Commands/App.cs
@@ -46,6 +46,7 @@ public static class App
             config.AddCommand<ConfigCommand>();
             config.AddCommand<InitCommand>();
             config.AddCommand<ListCommand>();
+            config.AddCommand<RemoveCommand>();
             config.AddCommand<SyncCommand>();
             config.AddCommand<ViewCommand>();
             config.AddCommand<WelcomeCommand>();

--- a/src/Commands/Commands.csproj
+++ b/src/Commands/Commands.csproj
@@ -10,14 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="RemoveCommand.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="RemoveCommand.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="NuGetizer" Version="1.2.1" PrivateAssets="all" />

--- a/src/Commands/GitHubAppAuthenticator.cs
+++ b/src/Commands/GitHubAppAuthenticator.cs
@@ -7,11 +7,16 @@ namespace Devlooped.Sponsors;
 
 public interface IGitHubAppAuthenticator
 {
-    Task<string?> AuthenticateAsync(string clientId, IProgress<string> progress, bool interactive, string @namespace = "sponsorlink");
+    Task<string?> AuthenticateAsync(string clientId, IProgress<string> progress, bool interactive, string @namespace = GitHubAppAuthenticator.DefaultNamespace);
 }
 
 public class GitHubAppAuthenticator(IHttpClientFactory httpFactory) : IGitHubAppAuthenticator
 {
+    /// <summary>
+    /// Default namespace used to scope credentials stored by this authenticator.
+    /// </summary>
+    public const string DefaultNamespace = "com.devlooped";
+
     static readonly JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
     {
         Converters = { new JsonStringEnumConverter<AuthError>() },
@@ -22,7 +27,7 @@ public class GitHubAppAuthenticator(IHttpClientFactory httpFactory) : IGitHubApp
     // confusing experience for the user, with multiple browser tabs opening.
     readonly SemaphoreSlim semaphore = new(1, 1);
 
-    public async Task<string?> AuthenticateAsync(string clientId, IProgress<string> progress, bool interactive, string @namespace = "sponsorlink")
+    public async Task<string?> AuthenticateAsync(string clientId, IProgress<string> progress, bool interactive, string @namespace = DefaultNamespace)
     {
         using var http = httpFactory.CreateClient("GitHub");
 

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -183,17 +183,11 @@ Code for the backend as well as this CLI extension are [link=https://www.devloop
   <data name="No" xml:space="preserve">
     <value>No</value>
   </data>
-  <data name="Remove_AuthenticationRequired" xml:space="preserve">
-    <value>[red]x[/] Removal of user data requires an authenticated user.</value>
-  </data>
-  <data name="Remove_Deleted" xml:space="preserve">
-    <value>[green]✓[/] Deleted authenticated user from backend</value>
-  </data>
   <data name="Remove_Deleting" xml:space="preserve">
-    <value>Requesting removal of all user data ...</value>
+    <value>Notifying removal of backend data...</value>
   </data>
   <data name="Remove_ReportIssue" xml:space="preserve">
-    <value>[red]x[/] Failed to remove user data. Please report the issue at [link]https://github.com/devlooped/SponsorLink/issues/new[/]</value>
+    <value>:cross_mark: Failed to remove user data. Please report the issue at [link]https://github.com/devlooped/SponsorLink/issues/new[/]</value>
   </data>
   <data name="Session_OpenBrowser" xml:space="preserve">
     <value>[lime]?[/] Operation requires authentication on github.com. Open your browser now?</value>
@@ -293,5 +287,32 @@ Code for the backend as well as this CLI extension are [link=https://www.devloop
   </data>
   <data name="Sync_UnattendedWithInteractiveAuth" xml:space="preserve">
     <value>[lime]?[/] Sponsors account [yellow]{account}[/] requires [link=https://www.devlooped.com/SponsorLink/github.html#authentication][blue]interactive authentication[/][/] for synchronization. Please run [yellow]gh sponsors sync {account}[/] interactively.</value>
+  </data>
+  <data name="Remove_AllOrSponsorable" xml:space="preserve">
+    <value>Either specify a sponsorable or use --all to remove all manifests.</value>
+  </data>
+  <data name="Remove_Removing" xml:space="preserve">
+    <value>Processing [lime]{sponsorable}[/]</value>
+  </data>
+  <data name="Remove_NoSponsorables" xml:space="preserve">
+    <value>:cross_mark: No manifests found to remove.</value>
+  </data>
+  <data name="Remove_AuthMissing" xml:space="preserve">
+    <value>:check_mark_button: [yellow]{sponsorable}[/]: deleted manifest, no auth found to invoke issuer backend</value>
+  </data>
+  <data name="Remove_Deleted" xml:space="preserve">
+    <value>:check_mark_button: [lime]{sponsorable}[/]: deleted manifest and invoked issuer delete endpoint successfully</value>
+  </data>
+  <data name="Remove_Invalid" xml:space="preserve">
+    <value>:cross_mark: Manifest for [yellow]{sponsorable}[/] was invalid and deleted</value>
+  </data>
+  <data name="Remove_NotFound" xml:space="preserve">
+    <value>:cross_mark: Manifest for [yellow]{sponsorable}[/] not found</value>
+  </data>
+  <data name="Remove_ServerError" xml:space="preserve">
+    <value>:check_mark_button: [yellow]{sponsorable}[/]: deleted manifest, issuer backend failed with unknown error</value>
+  </data>
+  <data name="Remove_Unauthorized" xml:space="preserve">
+    <value>:check_mark_button: [yellow]{sponsorable}[/]: deleted manifest, issuer backend could not authenticate user (access revoked already?)</value>
   </data>
 </root>

--- a/src/Commands/SyncCommand.cs
+++ b/src/Commands/SyncCommand.cs
@@ -50,7 +50,7 @@ public partial class SyncCommand(ICommandApp app, Config config, IGraphQueryClie
         /// Property used to modify the namespace from tests for scoping stored passwords.
         /// </summary>
         [CommandOption("--namespace", IsHidden = true)]
-        public string Namespace { get; set; } = "com.devlooped";
+        public string Namespace { get; set; } = GitHubAppAuthenticator.DefaultNamespace;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, SyncSettings settings)

--- a/src/Tests/RemoveCommandTests.cs
+++ b/src/Tests/RemoveCommandTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Devlooped.Sponsors;
+using DotNetConfig;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Spectre.Console.Cli;
+using static Devlooped.Helpers;
+using static Devlooped.Sponsors.Process;
+
+namespace Devlooped.Tests;
+
+[Collection("GitHub")]
+public class RemoveCommandTests
+{
+    Config config = Config.Build();
+
+    [SecretsFact("GitHub:Token")]
+    public async Task RemoveInvokesHttpDeleteEndpoint()
+    {
+        EnsureAuthenticated("GitHub:Token");
+
+        var graph = new Mock<IGraphQueryClient>();
+        // Return default 'main' branch from GraphQueries.DefaultBranch
+        graph.Setup(x => x.QueryAsync(GraphQueries.DefaultBranch("devlooped", ".github"))).ReturnsAsync("main");
+
+        var command = new SyncCommand(
+            Mock.Of<ICommandApp>(MockBehavior.Strict),
+            config,
+            graph.Object,
+            new GitHubAppAuthenticator(Services.GetRequiredService<IHttpClientFactory>()),
+            Services.GetRequiredService<IHttpClientFactory>());
+
+        var result = await command.ExecuteAsync(new CommandContext(["sync"], Mock.Of<IRemainingArguments>(), "sync", null), new SyncCommand.SyncSettings
+        {
+            Sponsorable = ["devlooped"],
+            // NOTE: would only succeed if we hav previously sync'ed at least once with the devlooped gh app
+            // so that the access token is cached.
+            Unattended = true,
+        });
+
+        Assert.Equal(0, result);
+
+        var handler = new Mock<IHttpMessageHandler>(MockBehavior.Strict);
+        handler.Setup(h => h.Send(It.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Delete && m.RequestUri!.PathAndQuery == "/me")))
+            .Throws<NotImplementedException>();
+
+        var removeCommand = new RemoveCommand(
+            CreateMockedHttp(handler.Object),
+            new GitHubAppAuthenticator(Services.GetRequiredService<IHttpClientFactory>()));
+
+        await Assert.ThrowsAsync<NotImplementedException>(() => removeCommand.ExecuteAsync(new CommandContext(["remove", "devlooped"], Mock.Of<IRemainingArguments>(), "remove", null),
+            new RemoveCommand.RemoveSettings { Sponsorable = ["devlooped"] }));
+    }
+
+    IHttpClientFactory CreateMockedHttp(IHttpMessageHandler mock) => new ServiceCollection()
+            .AddHttpClient()
+            .ConfigureHttpClientDefaults(c => c.ConfigurePrimaryHttpMessageHandler(() => new MockHttpHandler(mock)))
+            .BuildServiceProvider()
+            .GetRequiredService<IHttpClientFactory>();
+
+    class MockHttpHandler(IHttpMessageHandler handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(handler.Send(request));
+    }
+
+    public interface IHttpMessageHandler
+    {
+        HttpResponseMessage Send(HttpRequestMessage request);
+    }
+
+    void EnsureAuthenticated(string secret = "GitHub:Token")
+    {
+        if (!config.TryGetBoolean("sponsorlink", "firstrun", out var firstRunCompleted) || !firstRunCompleted)
+            config = config.SetBoolean("sponsorlink", "firstrun", true);
+
+        if (!TryExecute("gh", "auth status", out var status))
+        {
+            Assert.True(TryExecute("gh", "auth login --with-token", Configuration[secret]!, out var output));
+            Assert.True(TryExecute("gh", "auth status", out status));
+        }
+    }
+}


### PR DESCRIPTION
This allows removing the manifest and invoking `DELETE /me` on the issuer backend for potential removal of user-related traces and data (GDPR compliance).