### PR TITLE
Delete credentials when removing manifests, add global clear

### DIFF
--- a/src/Commands/ConfigCommand.cs
+++ b/src/Commands/ConfigCommand.cs
@@ -1,8 +1,9 @@
 ﻿using System.ComponentModel;
 using DotNetConfig;
+using Spectre.Console;
 using Spectre.Console.Cli;
 using static Spectre.Console.AnsiConsole;
-using static ThisAssembly.Strings;
+using static ThisAssembly;
 
 namespace Devlooped.Sponsors;
 
@@ -14,6 +15,16 @@ public class ConfigCommand(Config config) : Command<ConfigCommand.ConfigSettings
         [Description("Enable or disable automatic synchronization of expired manifests.")]
         [CommandOption("--autosync")]
         public bool? AutoSync { get; set; }
+
+        [Description("Clear all cached credentials used for manifest synchronization.")]
+        [CommandOption("--clear")]
+        public bool? Clear { get; set; }
+
+        /// <summary>
+        /// Property used to modify the namespace from tests for scoping stored passwords.
+        /// </summary>
+        [CommandOption("--namespace", IsHidden = true)]
+        public string Namespace { get; set; } = "com.devlooped";
     }
 
     public override int Execute(CommandContext context, ConfigSettings settings)
@@ -23,9 +34,22 @@ public class ConfigCommand(Config config) : Command<ConfigCommand.ConfigSettings
             // We persist as a string since that makes it easier to parse from MSBuild.
             config.SetString("sponsorlink", "autosync", settings.AutoSync.Value.ToString().ToLowerInvariant());
             if (settings.AutoSync == true)
-                MarkupLine(Sync.AutoSyncEnabled);
+                MarkupLine(Strings.Sync.AutoSyncEnabled);
             else
-                MarkupLine(Sync.AutoSyncDisabled);
+                MarkupLine(Strings.Sync.AutoSyncDisabled);
+        }
+
+        if (settings.Clear == true)
+        {
+            // Check existing creds, if any
+            var store = GitCredentialManager.CredentialManager.Create(settings.Namespace);
+            var accounts = store.GetAccounts("https://github.com");
+            foreach (var clientId in accounts)
+                store.Remove("https://github.com", clientId);
+
+            MarkupLine(Strings.Config.Clear(accounts.Count));
+            foreach (var clientId in accounts)
+                Write(new Padder(new Markup(Strings.Config.ClearClientId(clientId)), new Padding(3, 0, 0, 0)));
         }
 
         return 0;

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -183,12 +183,6 @@ Code for the backend as well as this CLI extension are [link=https://www.devloop
   <data name="No" xml:space="preserve">
     <value>No</value>
   </data>
-  <data name="Remove_Deleting" xml:space="preserve">
-    <value>Notifying removal of backend data...</value>
-  </data>
-  <data name="Remove_ReportIssue" xml:space="preserve">
-    <value>:cross_mark: Failed to remove user data. Please report the issue at [link]https://github.com/devlooped/SponsorLink/issues/new[/]</value>
-  </data>
   <data name="Session_OpenBrowser" xml:space="preserve">
     <value>[lime]?[/] Operation requires authentication on github.com. Open your browser now?</value>
   </data>
@@ -297,22 +291,37 @@ Code for the backend as well as this CLI extension are [link=https://www.devloop
   <data name="Remove_NoSponsorables" xml:space="preserve">
     <value>:cross_mark: No manifests found to remove.</value>
   </data>
-  <data name="Remove_AuthMissing" xml:space="preserve">
-    <value>:check_mark_button: [yellow]{sponsorable}[/]: deleted manifest, no auth found to invoke issuer backend</value>
-  </data>
-  <data name="Remove_Deleted" xml:space="preserve">
-    <value>:check_mark_button: [lime]{sponsorable}[/]: deleted manifest and invoked issuer delete endpoint successfully</value>
-  </data>
-  <data name="Remove_Invalid" xml:space="preserve">
-    <value>:cross_mark: Manifest for [yellow]{sponsorable}[/] was invalid and deleted</value>
+  <data name="Remove_InvalidManifest" xml:space="preserve">
+    <value>:yellow_square: Invalid manifest, no credentials or issuer to process</value>
   </data>
   <data name="Remove_NotFound" xml:space="preserve">
-    <value>:cross_mark: Manifest for [yellow]{sponsorable}[/] not found</value>
+    <value>:cross_mark: [yellow]{sponsorable}[/]: manifest not found</value>
   </data>
-  <data name="Remove_ServerError" xml:space="preserve">
-    <value>:check_mark_button: [yellow]{sponsorable}[/]: deleted manifest, issuer backend failed with unknown error</value>
+  <data name="Config_ClearClientId" xml:space="preserve">
+    <value>:backhand_index_pointing_right: [link]https://github.com/settings/connections/applications/{client_id}[/]</value>
+  </data>
+  <data name="Remove_DeletedCreds" xml:space="preserve">
+    <value>:backhand_index_pointing_right: Deleted local credentials. [link=https://github.com/settings/connections/applications/{client_id}]Review app at access :globe_showing_americas:github.com[/]</value>
+  </data>
+  <data name="Remove_DeletedManifest" xml:space="preserve">
+    <value>:backhand_index_pointing_right: Deleted manifest from [link][grey]{path}[/][/]</value>
+  </data>
+  <data name="Remove_DeleteEndpoint" xml:space="preserve">
+    <value>:backhand_index_pointing_right: Sent delete to {uri}</value>
+  </data>
+  <data name="Remove_Done" xml:space="preserve">
+    <value>:check_mark_button: [lime]{sponsorable}[/]</value>
+  </data>
+  <data name="Remove_IssuerFailure" xml:space="preserve">
+    <value>:raised_hand: Sent delete to {uri} failed with unknown issuer backend error</value>
+  </data>
+  <data name="Remove_NoCredsFound" xml:space="preserve">
+    <value>:raised_hand: No local credentials found to delete from {uri}. [link=https://github.com/settings/connections/applications/{client_id}]Review app access at :globe_showing_americas:github.com[/]</value>
   </data>
   <data name="Remove_Unauthorized" xml:space="preserve">
-    <value>:check_mark_button: [yellow]{sponsorable}[/]: deleted manifest, issuer backend could not authenticate user (access revoked already?)</value>
+    <value>:raised_hand: Sent delete to {uri} failed to authorize (access revoked already?)</value>
+  </data>
+  <data name="Config_Clear" xml:space="preserve">
+    <value>:check_mark_button: Cleared {count} cached credentials. Review app access for the following client ids:</value>
   </data>
 </root>

--- a/src/Commands/SyncCommand.cs
+++ b/src/Commands/SyncCommand.cs
@@ -10,7 +10,7 @@ using static ThisAssembly.Strings;
 namespace Devlooped.Sponsors;
 
 [Description("Synchronizes the sponsorships manifest")]
-public partial class SyncCommand(ICommandApp app, Config config, IGraphQueryClient client, IGitHubAppAuthenticator authenticator, IHttpClientFactory httpFactory) : GitHubAsyncCommand<SyncCommand.SyncSettings>(app, config)
+public partial class SyncCommand(ICommandApp app, DotNetConfig.Config config, IGraphQueryClient client, IGitHubAppAuthenticator authenticator, IHttpClientFactory httpFactory) : GitHubAsyncCommand<SyncCommand.SyncSettings>(app, config)
 {
     public static class ErrorCodes
     {
@@ -226,7 +226,7 @@ public partial class SyncCommand(ICommandApp app, Config config, IGraphQueryClie
             }
         }
 
-        var config = Config.Build(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".sponsorlink"));
+        var config = DotNetConfig.Config.Build(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".sponsorlink"));
         var autosync = settings.AutoSync;
 
         if (!settings.Unattended &&


### PR DESCRIPTION
The new `config --clear` will remove all cached creds. Should make it easier to reset the creds used for each sponsorable account (interactive login will be needed for each again to sync/refresh).

Improved rendering of messages when removing manifests, since we now also delete creds so we don't leave those behind.