### PR TITLE
Allow accepting the ToS programmatically

### DIFF
--- a/src/Commands/App.cs
+++ b/src/Commands/App.cs
@@ -13,7 +13,8 @@ public static class App
     {
         var collection = new ServiceCollection();
 
-        collection.AddSingleton(sp =>
+        // Made transient so each command gets a new copy with potentially updated values.
+        collection.AddTransient(sp =>
         {
             var sldir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".sponsorlink");
             Directory.CreateDirectory(sldir);
@@ -49,7 +50,7 @@ public static class App
             config.AddCommand<RemoveCommand>();
             config.AddCommand<SyncCommand>();
             config.AddCommand<ViewCommand>();
-            config.AddCommand<WelcomeCommand>();
+            config.AddCommand<WelcomeCommand>().IsHidden();
         });
 
         services = registrar.Services.BuildServiceProvider();

--- a/src/Commands/ConfigCommand.cs
+++ b/src/Commands/ConfigCommand.cs
@@ -10,7 +10,7 @@ namespace Devlooped.Sponsors;
 [Description("Manages sponsorlink configuration")]
 public class ConfigCommand(Config config) : Command<ConfigCommand.ConfigSettings>
 {
-    public class ConfigSettings : CommandSettings
+    public class ConfigSettings : ToSSettings
     {
         [Description("Enable or disable automatic synchronization of expired manifests.")]
         [CommandOption("--autosync")]
@@ -29,14 +29,17 @@ public class ConfigCommand(Config config) : Command<ConfigCommand.ConfigSettings
 
     public override int Execute(CommandContext context, ConfigSettings settings)
     {
-        if (settings.AutoSync != null)
+        if (settings.AutoSync == true)
         {
             // We persist as a string since that makes it easier to parse from MSBuild.
-            config.SetString("sponsorlink", "autosync", settings.AutoSync.Value.ToString().ToLowerInvariant());
-            if (settings.AutoSync == true)
-                MarkupLine(Strings.Sync.AutoSyncEnabled);
-            else
-                MarkupLine(Strings.Sync.AutoSyncDisabled);
+            config.SetString("sponsorlink", "autosync", "true");
+            MarkupLine(Strings.Sync.AutoSyncEnabled);
+        }
+        else if (settings.AutoSync == false)
+        {
+            // NOTE: should we just unset instead?
+            config.SetString("sponsorlink", "autosync", "false");
+            MarkupLine(Strings.Sync.AutoSyncDisabled);
         }
 
         if (settings.Clear == true)
@@ -50,6 +53,17 @@ public class ConfigCommand(Config config) : Command<ConfigCommand.ConfigSettings
             MarkupLine(Strings.Config.Clear(accounts.Count));
             foreach (var clientId in accounts)
                 Write(new Padder(new Markup(Strings.Config.ClearClientId(clientId)), new Padding(3, 0, 0, 0)));
+        }
+
+        if (settings.ToS == false)
+        {
+            config.Unset("sponsorlink", "tos");
+            MarkupLine(Strings.Config.ToSCleared);
+        }
+        else if (settings.ToS == true)
+        {
+            config.SetString("sponsorlink", "tos", "true");
+            MarkupLine(Strings.Config.ToSAccepted);
         }
 
         return 0;

--- a/src/Commands/InitCommand.cs
+++ b/src/Commands/InitCommand.cs
@@ -13,7 +13,7 @@ namespace Devlooped.Sponsors;
 [Description("Initializes a sponsorable manifest and token")]
 public partial class InitCommand : AsyncCommand<InitCommand.Settings>
 {
-    public class Settings : CommandSettings
+    public class Settings : ToSSettings
     {
         [Description("The base URL of the manifest issuer web app.")]
         [CommandOption("-i|--issuer")]

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -130,28 +130,27 @@
     <value>Welcome to SponsorLink</value>
   </data>
   <data name="FirstRun_What" xml:space="preserve">
-    <value>SponsorLink is a manifest-based (JWTs) mechanism for synchronizing your sponsorships to your local machine. This allows package authors that leverage SponsorLink to provide selective functionality to sponsors, whether individual or organization-wide.</value>
+    <value>SponsorLink syncs your sponsorship(s) to your local machine, enabling package authors to provide selective functionality to sponsors.</value>
     <comment>What</comment>
   </data>
   <data name="FirstRun_How" xml:space="preserve">
-    <value>As a GitHub CLI extension, [italic]gh-sponsors[/] leverages your authenticated user to locate your personal sponsorships, as well as your organizations' and your OSS community contributions. It does this entirely locally with no intermediaries, communicating exclusively with the GitHub API itself.
-
-This information is then used to discover GitHub sponsors accounts that have opted-in to use SponsorLink, by looking up their sponsorable JWT manifest, such as [link=https://github.com/devlooped/.github/blob/main/sponsorlink.jwt][blue]https://github.com/[/][dim][[user/org]][/][blue]/.github/sponsorlink.jwt[/][/]. If the manifest is present, the extension will:
-
-:backhand_index_pointing_right: read from the manifest the issuer URI, public key and GitHub OAuth client (app) ID
+    <value>GitHub users and organizations using [link=https://github.com/sponsors/]GitHub Sponsors[/] (a.k.a. [italic]sponsorables[/]) can opt-in to SponsorLink by providing [link=https://www.devlooped.com/SponsorLink/spec.html#sponsorable-manifest]a standard JWT manifest[/] at [link=https://github.com/devlooped/.github/blob/main/sponsorlink.jwt][blue]https://github.com/[/][dim][[user/org]][/][blue]/.github/sponsorlink.jwt[/][/]. This is the same location used for other [link=https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file]community health files[/]. 
+    
+When you synchronize your sponsorship with a given account, the following steps take place:
+    
+:backhand_index_pointing_right: read sponsorable JWT manifest from [blue]https://github.com/[/][dim][[user/org]][/][blue]/.github/sponsorlink.jwt[/] ([link=https://github.com/devlooped/.github/blob/main/sponsorlink.jwt][blue]example[/][/])
+:backhand_index_pointing_right: read from the manifest the issuer URI, public key and the sponsorable's GitHub OAuth client (app) ID
 :backhand_index_pointing_right: request GitHub OAuth app authorization via the default browser to get a limited acccess token
-   :eyes: you should read the permissions requested by the sponsor account's GitHub app carefully
+   :eyes: you should read the permissions requested by the sponsorable's GitHub app carefully
    :check_mark_button: you can revoke these permissions at any time at [link]https://github.com/settings/applications[/]
-:backhand_index_pointing_right: issue a GET request with that limited token to [blue][[issuer URI]]/sync[/] and get a sponsor JWT manifest 
+:backhand_index_pointing_right: issue a GET request with that limited token to [blue][[issuer URI]]/me[/] and get a sponsor JWT manifest 
    :eyes: the backend will only have access to the information you authorized
 :backhand_index_pointing_right: verify and save sponsor JWT manifest locally for later offline access and validation by libraries and tools
+  :eyes: Sponsor manifests are cached under [blue]~/.sponsorlink[/] ([blue]%userprofile%\.sponsorlink[/] on Windows).
 
-You can also inspect the JWT of both the sponsorable account and your sponsor manifest using [link]https://jwt.io/[/], for example. 
-Both are persisted under [blue]~/.sponsorlink[/] ([blue]%userprofile%\.sponsorlink[/] on Windows).
+You can easily inspect the JWT of both the sponsorable account and your sponsor manifest using [link]https://jwt.io/[/], for example. 
 
-This manifest needs to be sync'ed and downloaded once a month, which is the only point at which each SponsorLink backend computes, signs your sponsorship token and sets a new expiration date.
-
-Learn more about SponsorLink at [link]https://www.devlooped.com/SponsorLink/[/].</value>
+This manifest needs to be sync'ed once a month, which is the only point at which each SponsorLink backend computes, signs your sponsorship manifest and sets a new expiration date. You can also enable [link=https://www.devlooped.com/SponsorLink/github.html#auto-sync]automatic synchronization[/]. Learn more yat [link]https://www.devlooped.com/SponsorLink/[/].</value>
     <comment>How</comment>
   </data>
   <data name="FirstRun_HowTitle" xml:space="preserve">
@@ -163,28 +162,19 @@ Learn more about SponsorLink at [link]https://www.devlooped.com/SponsorLink/[/].
 The short story is: 
 :backhand_index_pointing_right: sponsorship manifests are purely local and offline :check_mark_button: no info persisted in the cloud
 :backhand_index_pointing_right: the backend uses a limited GitHub OAuth app token  :check_mark_button: only email(s) and organization membership determine sponsorships
-:backhand_index_pointing_right: you can be a direct or indirect supporter/sponsor  :purple_heart: direct sponsorship, via an organization or project contributions 
+:backhand_index_pointing_right: you can be a direct or indirect supporter/sponsor  :purple_heart: indirect sponsorship via an organization or project contributions 
 
-Code for the backend as well as this CLI extension are [link=https://www.devlooped.com/SponsorLink/]open source[/]. Please read the [link=https://github.com/devlooped/SponsorLink/blob/main/privacy.md]full privacy policy[/] to learn more.</value>
+Code for the backend and this app are [link=https://www.devlooped.com/SponsorLink/]open source[/]. Please read the [link=https://github.com/devlooped/SponsorLink/blob/main/privacy.md]full privacy policy[/] to learn more.</value>
     <comment>Privacy</comment>
   </data>
   <data name="FirstRun_PrivacyTitle" xml:space="preserve">
     <value>Privacy policy</value>
   </data>
-  <data name="FirstRun_SyncNow" xml:space="preserve">
-    <value>[lime]?[/] [white]Do you want to sync your sponsor manifests now?[/]</value>
-  </data>
   <data name="GitHub_Login" xml:space="preserve">
     <value>[lime]?[/] [white]Do you want to log into the GitHub CLI?[/]</value>
   </data>
-  <data name="GitHub_UserScope" xml:space="preserve">
-    <value>[lime]?[/] [white]Allow read-access to your GitHub account email address(es)?[/] (Required for manifest generation)</value>
-  </data>
   <data name="No" xml:space="preserve">
     <value>No</value>
-  </data>
-  <data name="Session_OpenBrowser" xml:space="preserve">
-    <value>[lime]?[/] Operation requires authentication on github.com. Open your browser now?</value>
   </data>
   <data name="Sync_ConsiderSponsoring" xml:space="preserve">
     <value>:folded_hands: [yellow]{sponsorable}[/]: consider sponsoring at {links}</value>
@@ -323,5 +313,11 @@ Code for the backend as well as this CLI extension are [link=https://www.devloop
   </data>
   <data name="Config_Clear" xml:space="preserve">
     <value>:check_mark_button: Cleared {count} cached credentials. Review app access for the following client ids:</value>
+  </data>
+  <data name="Config_ToSCleared" xml:space="preserve">
+    <value>:check_mark_button: Cleared usage terms acceptance</value>
+  </data>
+  <data name="Config_ToSAccepted" xml:space="preserve">
+    <value>:check_mark_button: Saved usage terms acceptance</value>
   </data>
 </root>

--- a/src/Commands/RemoveCommand.cs
+++ b/src/Commands/RemoveCommand.cs
@@ -11,9 +11,9 @@ namespace Devlooped.Sponsors;
 [Description("Removes all manifests and notifies issuers to remove backend data too.")]
 public class RemoveCommand(IHttpClientFactory httpFactory, IGitHubAppAuthenticator authenticator) : AsyncCommand<RemoveCommand.RemoveSettings>
 {
-    public class RemoveSettings : CommandSettings
+    public class RemoveSettings : ToSSettings
     {
-        [Description("Sponsored account(s) to synchronize.")]
+        [Description("Sponsored account(s) to remove.")]
         [CommandArgument(0, "[sponsorable]")]
         public string[]? Sponsorable { get; set; }
 

--- a/src/Commands/SyncCommand.cs
+++ b/src/Commands/SyncCommand.cs
@@ -23,7 +23,7 @@ public partial class SyncCommand(ICommandApp app, DotNetConfig.Config config, IG
         public const int SyncFailure = -7;
     }
 
-    public class SyncSettings : CommandSettings
+    public class SyncSettings : ToSSettings
     {
         [Description("Optional sponsored account(s) to synchronize.")]
         [CommandArgument(0, "[sponsorable]")]
@@ -55,15 +55,7 @@ public partial class SyncCommand(ICommandApp app, DotNetConfig.Config config, IG
 
     public override async Task<int> ExecuteAsync(CommandContext context, SyncSettings settings)
     {
-        var firstRunCompleted = config.TryGetBoolean("sponsorlink", "firstrun", out var completed) && completed;
-
-        if (!firstRunCompleted &&
-            app.Run(["welcome"]) is var welcome &&
-            welcome < 0)
-        {
-            return welcome;
-        }
-
+        // NOTE: ToS acceptance ALWAYS runs from Program.cs
         var result = 0;
         var ghDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".sponsorlink", "github");
         Directory.CreateDirectory(ghDir);

--- a/src/Commands/ToSSettings.cs
+++ b/src/Commands/ToSSettings.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace Devlooped.Sponsors;
+
+public class ToSSettings : CommandSettings
+{
+    public const string ToSOption = "--tos";
+
+    /// <summary>
+    /// Allows explicit acceptance of the terms of service.
+    /// </summary>
+    [Description("Explicitly accept the [blue]terms of service[/] if they haven't been accepted already.")]
+    [CommandOption(ToSOption, IsHidden = true)]
+    public bool? ToS { get; set; }
+}

--- a/src/Commands/ViewCommand.cs
+++ b/src/Commands/ViewCommand.cs
@@ -14,7 +14,7 @@ namespace Devlooped.Sponsors;
 [Description("Validates and displays the active sponsor manifests, if any")]
 public partial class ViewCommand(IHttpClientFactory clientFactory) : AsyncCommand<ViewCommand.ViewSettings>
 {
-    public class ViewSettings : CommandSettings
+    public class ViewSettings : ToSSettings
     {
         [Description("Show detailed information about each manifest")]
         [CommandOption("-d|--details")]

--- a/src/Commands/WelcomeCommand.cs
+++ b/src/Commands/WelcomeCommand.cs
@@ -8,7 +8,7 @@ namespace Devlooped.Sponsors;
 [Description("Executes the first-run experience")]
 public class WelcomeCommand(ICommandApp app, Config config) : Command<WelcomeCommand.WelcomeSettings>
 {
-    public class WelcomeSettings : CommandSettings
+    public class WelcomeSettings : ToSSettings
     {
         [CommandOption("--welcome", IsHidden = true)]
         public bool Force { get; set; }
@@ -16,6 +16,13 @@ public class WelcomeCommand(ICommandApp app, Config config) : Command<WelcomeCom
 
     public override int Execute(CommandContext context, WelcomeSettings settings)
     {
+        if (settings.ToS == true)
+        {
+            // Accept unattended.
+            config.SetString("sponsorlink", "tos", "true");
+            return 0;
+        }
+
         AnsiConsole.Write(new Panel(new Rows(
             new Markup(ThisAssembly.Strings.FirstRun.What)))
         {
@@ -44,13 +51,7 @@ public class WelcomeCommand(ICommandApp app, Config config) : Command<WelcomeCom
             return -1;
         }
 
-        config.SetString("sponsorlink", "firstrun", "true");
-
-        if (AnsiConsole.Confirm(ThisAssembly.Strings.FirstRun.SyncNow))
-        {
-            return app.Run(["sync"]);
-        }
-
+        config.SetString("sponsorlink", "tos", "true");
         return 0;
     }
 }

--- a/src/Tests/SyncCommandTests.cs
+++ b/src/Tests/SyncCommandTests.cs
@@ -13,45 +13,6 @@ public class SyncCommandTests
 {
     Config config = Config.Build();
 
-    [LocalFact]
-    public async Task FirstRunWelcome()
-    {
-        config = config.Unset("sponsorlink", "firstrun");
-
-        var command = new SyncCommand(
-            Mock.Of<ICommandApp>(x => x.Run(It.Is<IEnumerable<string>>(args => args.Contains("welcome"))) == -42),
-            config,
-            Mock.Of<IGraphQueryClient>(MockBehavior.Strict),
-            Mock.Of<IGitHubAppAuthenticator>(MockBehavior.Strict),
-            Mock.Of<IHttpClientFactory>(MockBehavior.Strict));
-
-        var result = await command.ExecuteAsync(new CommandContext(["sync"], Mock.Of<IRemainingArguments>(), "sync", null), new SyncCommand.SyncSettings());
-
-        Assert.Equal(-42, result);
-    }
-
-    [LocalFact]
-    public async Task FirstRunWelcomeCompleted()
-    {
-        config = config.SetBoolean("sponsorlink", "firstrun", true);
-
-        // By forcing an unauthenticated CLI, we can shortcircuit the execution at the login
-        if (TryExecute("gh", "auth status", out var status))
-            Assert.True(TryExecute("gh", "auth logout --hostname github.com", out var output));
-
-        var command = new SyncCommand(
-            Mock.Of<ICommandApp>(MockBehavior.Strict),
-            config,
-            Mock.Of<IGraphQueryClient>(MockBehavior.Strict),
-            Mock.Of<IGitHubAppAuthenticator>(MockBehavior.Strict),
-            Mock.Of<IHttpClientFactory>(MockBehavior.Strict));
-
-        var result = await command.ExecuteAsync(new CommandContext(["sync"], Mock.Of<IRemainingArguments>(), "sync", null), new SyncCommand.SyncSettings());
-
-        // unauthenticated GH CLI
-        Assert.Equal(-1, result);
-    }
-
     [LocalFact("GitHub:Token")]
     public async Task NoSponsorableOrLocalDiscoveryRunsGraphDiscoveryViewerSponsored()
     {


### PR DESCRIPTION
By passing `--tos` to commands that support it, including `sync`. The `Welcome` command should not be visible.