### PR TITLE
Add --force option to sync all accounts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ and make sure to check the [privacy statement](https://www.devlooped.com/Sponsor
 
 ## Integrating via NuGet for .NET
 
-The reference implementation .NET global tool, `dotnet-sponsors`, provides generic 
+The reference implementation .NET global tool, `dotnet-sponsor`, provides generic 
 manifest discovery and sync capabilities, but the actual check from within a library 
 or tool is left to the author.
 

--- a/src/Cli/readme.md
+++ b/src/Cli/readme.md
@@ -18,8 +18,10 @@ ARGUMENTS:
 OPTIONS:
     -h, --help          Prints help information
         --autosync      Enable or disable automatic synchronization of expired manifests
-    -u, --unattended    Whether to prevent interactive credentials refresh
     -l, --local         Sync only existing local manifests
+    -f, --force         Force sync, regardless of expiration of manifests found locally
+    -v, --validate      Whether to always validate local manifests using the issuer public key
+    -u, --unattended    Whether to prevent interactive credentials refresh
         --with-token    Read GitHub authentication token from standard input for sync
 ```
 

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -329,4 +329,7 @@ Code for the backend and this app are [link=https://www.devlooped.com/SponsorLin
   <data name="Sync_LocalOrSponsorables" xml:space="preserve">
     <value>Cannot specify both --local and specific accounts.</value>
   </data>
+  <data name="Sync_ManifestNotExpired" xml:space="preserve">
+    <value>:check_mark_button: [lime]{sponsorable}[/]: manifest expires [yellow]{date}[/] [dim](roles: {roles})[/]</value>
+  </data>
 </root>


### PR DESCRIPTION
Currently, we always act as if a (previously non-existent) `--force` option was specified: we never check existing local manifests for expiration and always call the backend on sync.

It's desirable to make this forced sync an opt-in instead: if an existing local manifest hasn't expired, assume it's valid. If it was tampered with, the tool/library can determine that upon reading it with full validation using the sponsorable public token.

In order to make the non-forced run as fast as possible, we don't even fetch the issuer manifest to get the public key for validation by default, unless the `--validate` option is specified too.