### PR TITLE
Add basic anonymous usage telemetry

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -113,6 +113,16 @@ token from the standard input, which can be piped from a secure store or environ
 ```
 <!-- {% endraw %} -->
 
+### Telemetry
+
+The `dotnet-sponsor` tool does not collect any telemetry by itself. Sponsor backend services may collect 
+anonymous usage telemetry to improve your experience, however. Such telemetry is associated by default 
+with an opaque and random identifier of the tool installation that is not linked to any personal information. 
+
+Telemetry data helps the backend team understand how its APIs are used by the tool so they can be improved. 
+To opt out of associating the backend API invocations with your tool installation, set the 
+`SPONSOR_CLI_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
+
 ### Sponsoring Checks
 
 SponsorLink-enabled libraries and tools can use the previously synchronized sponsor manifest to check the 
@@ -245,9 +255,9 @@ To deploy and configure the backend:
 1. [Create an Azure Functions app](https://portal.azure.com/#create/Microsoft.FunctionApp)
 1. Setup deployment to the Azure Functions app from your forked repository
 1. Configure the following application settings:
-    * `GitHub__Token`: a GitHub token with permissions to read the sponsorable profile, emails, sponsorships and repositories
-    * `SponsorLink__Account`: the sponsorable GitHub account name, unless it's the same as the GitHub token owner
-    * `SponsorLink__PrivateKey`: the Base64-encoded private key (the contents of `curl.key.txt` in the example above)
+    * `GitHub:Token`: a GitHub token with permissions to read the sponsorable profile, emails, sponsorships and repositories
+    * `SponsorLink:Account`: the sponsorable GitHub account name, unless it's the same as the GitHub token owner
+    * `SponsorLink:PrivateKey`: the Base64-encoded private key (the contents of `curl.key.txt` in the example above)
 
 Finally, enable the GitHub identity provider under Settings > Authentication, providing the OAuth app's 
 Client ID and Client Secret. Make sure you set `Allow unauthenticated requests` and have `Token store` enabled.

--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -1,5 +1,4 @@
-﻿#pragma warning disable CS0436 // Type conflicts with imported type
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Devlooped.Sponsors;
 using DotNetConfig;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Cli/Properties/launchSettings.json
+++ b/src/Cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Cli": {
       "commandName": "Project",
-      "commandLineArgs": "remove devlooped"
+      "commandLineArgs": "sync devlooped --issuer https://donkey-emerging-civet.ngrok-free.app/ --force"
     }
   }
 }

--- a/src/Cli/readme.md
+++ b/src/Cli/readme.md
@@ -42,3 +42,6 @@ COMMANDS:
     sync      Synchronizes sponsorship manifests
     view      Validates and displays the active sponsor manifests, if any
 ```
+
+Learn more [about the tool](https://github.com/devlooped/SponsorLink/blob/main/docs/github.md#sponsor-manifest-sync) 
+and related [telemetry](https://github.com/devlooped/SponsorLink/blob/main/docs/github.md#telemetry).

--- a/src/Commands/Commands.csproj
+++ b/src/Commands/Commands.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Spectre.Console.Analyzer" Version="0.49.1" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Strings" Version="1.4.3" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.4.3" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Project" Version="1.4.3" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Constants" Version="1.4.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Commands/Extensions.cs
+++ b/src/Commands/Extensions.cs
@@ -29,8 +29,8 @@ public static class Extensions
         var header = $"|:magnifying_glass_tilted_left:[link={path}]~{Path.DirectorySeparatorChar}.sponsorlink{path[root.Length..]}[/] |";
 
         var content = new List<IRenderable>
-        { 
-            new JsonText(jwt.Payload.SerializeToJson()) 
+        {
+            new JsonText(jwt.Payload.SerializeToJson())
         };
 
         if (jwt.Claims.Where(c => c.Type == "client_id").Select(c => c.Value).FirstOrDefault() is string client_id)

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -332,4 +332,10 @@ Code for the backend and this app are [link=https://www.devlooped.com/SponsorLin
   <data name="Sync_ManifestNotExpired" xml:space="preserve">
     <value>:check_mark_button: [lime]{sponsorable}[/]: manifest expires [yellow]{date}[/] [dim](roles: {roles})[/]</value>
   </data>
+  <data name="FirstRun_Telemetry" xml:space="preserve">
+    <value>Each sponsor issuer backend may collect anonymous usage data telemetry to improve your experience. To send your preference to not get such telemetry collected, you can set a SPONSOR_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell. You can read more about telemetry [link=https://www.devlooped.com/SponsorLink/github.html#telemetry]in the docs[/].</value>
+  </data>
+  <data name="FirstRun_TelemetryTitle" xml:space="preserve">
+    <value>Telemetry</value>
+  </data>
 </root>

--- a/src/Commands/RemoveCommand.cs
+++ b/src/Commands/RemoveCommand.cs
@@ -85,7 +85,7 @@ public class RemoveCommand(IHttpClientFactory httpFactory, IGitHubAppAuthenticat
 
                 File.Delete(file);
                 MarkupLine(Remove.Done(sponsorable));
-                
+
                 var padding = new Padding(3, 0, 0, 0);
                 Write(new Padder(new Markup(Remove.DeletedManifest(Path.Combine("~", ".sponsorlink", "github", sponsorable + ".jwt"))), padding));
 

--- a/src/Commands/WelcomeCommand.cs
+++ b/src/Commands/WelcomeCommand.cs
@@ -46,6 +46,14 @@ public class WelcomeCommand(Config config) : Command<WelcomeCommand.WelcomeSetti
             Padding = new Padding(2, 1, 2, 0),
         });
 
+        AnsiConsole.Write(new Panel(new Rows(
+            new Rule(ThisAssembly.Strings.FirstRun.TelemetryTitle).RuleStyle(Color.MediumPurple2).LeftJustified(),
+            new Markup(ThisAssembly.Strings.FirstRun.Telemetry)))
+        {
+            Border = BoxBorder.None,
+            Padding = new Padding(2, 1, 2, 0),
+        });
+
         if (!AnsiConsole.Confirm(ThisAssembly.Strings.FirstRun.Acceptance))
         {
             return -1;

--- a/src/Core/ActivityTracer.cs
+++ b/src/Core/ActivityTracer.cs
@@ -1,0 +1,8 @@
+﻿using System.Diagnostics;
+
+namespace Devlooped.Sponsors;
+
+public static class ActivityTracer
+{
+    public static ActivitySource Source { get; } = new("Devlooped.Sponsors", ThisAssembly.Info.InformationalVersion);
+}

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -16,11 +16,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
     <PackageReference Include="Devlooped.JQ" Version="1.7.1.1" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.4.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="@(None)" CopyToOutputDirectory="PreserveNewest" />
-    <InternalsVisibleTo Include="Tests;Web" />
+    <InternalsVisibleTo Include="Devlooped.Sponsors.Commands;Tests;Web" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -10,6 +10,7 @@
     <EnablePackCleanup>false</EnablePackCleanup>
     <LangVersion>Preview</LangVersion>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <NoWarn>CS0436;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/GitHubFixture.cs
+++ b/src/Tests/GitHubFixture.cs
@@ -28,7 +28,7 @@ public sealed class GitHubCollection : ICollectionFixture<GitHubCollection.GitHu
         public void Dispose()
         {
             if (existingToken != null &&
-                TryExecute("gh", "auth token", out var currentToken) && 
+                TryExecute("gh", "auth token", out var currentToken) &&
                 existingToken != currentToken)
             {
                 Assert.True(TryExecute("gh", $"auth login --with-token", existingToken, out _));

--- a/src/Tests/Signing.cs
+++ b/src/Tests/Signing.cs
@@ -154,7 +154,7 @@ public class Signing(ITestOutputHelper Output)
         // NOTE: we cannot recreate the RSAPublicKey from the JWK, so we can never 
         // compare the raw string, but we can still validate with either one.
 
-        var principal1 = new JwtSecurityTokenHandler {  MapInboundClaims = false }.ValidateToken(jwt,
+        var principal1 = new JwtSecurityTokenHandler { MapInboundClaims = false }.ValidateToken(jwt,
             new TokenValidationParameters
             {
                 RequireExpirationTime = false,
@@ -166,7 +166,7 @@ public class Signing(ITestOutputHelper Output)
         var pubRsa = RSA.Create();
         pubRsa.ImportRSAPublicKey(rsa.ExportRSAPublicKey(), out _);
 
-        var principal2 = new JwtSecurityTokenHandler {  MapInboundClaims = false }.ValidateToken(jwt,
+        var principal2 = new JwtSecurityTokenHandler { MapInboundClaims = false }.ValidateToken(jwt,
             new TokenValidationParameters
             {
                 RequireExpirationTime = false,

--- a/src/Tests/SponsorableManifestTests.cs
+++ b/src/Tests/SponsorableManifestTests.cs
@@ -18,7 +18,7 @@ public class SponsorableManifestTests
         var jwt = manifest.ToJwt();
 
         // Ensures token is signed
-        var principal = new JwtSecurityTokenHandler {  MapInboundClaims = false }.ValidateToken(jwt, new TokenValidationParameters
+        var principal = new JwtSecurityTokenHandler { MapInboundClaims = false }.ValidateToken(jwt, new TokenValidationParameters
         {
             RequireExpirationTime = false,
             ValidateAudience = true,

--- a/src/Web/ActivityTelemetryExtensions.cs
+++ b/src/Web/ActivityTelemetryExtensions.cs
@@ -1,0 +1,149 @@
+﻿using System.Diagnostics;
+using System.Security.Claims;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Devlooped.Sponsors;
+
+/// <summary>
+/// Sets the <see cref="ClaimsPrincipal.ClaimsPrincipalSelector"/> to a function 
+/// that accesses the current <see cref="FunctionContext"/> by leveraging the 
+/// <see cref="IFunctionContextAccessor"/> to retrieve the principal from 
+/// the <see cref="FunctionContext.Features"/>, if present.
+/// </summary>
+public static partial class ActivityTelemetryExtensions
+{
+    static readonly HashSet<string> skipProps = ["faas.execution", "az.schema_url"];
+
+    /// <summary>
+    /// Ensures that <see cref="ClaimsPrincipal.Current"/> accesses the principal 
+    /// authenticated by the app service authentication middleware.
+    /// </summary>
+    public static IFunctionsWorkerApplicationBuilder UseActivityTelemetry(this IFunctionsWorkerApplicationBuilder builder)
+    {
+        builder.UseMiddleware<Middleware>();
+        return builder;
+    }
+
+    public static IServiceCollection AddActivityTelemetry(this IServiceCollection services)
+    {
+        services.AddSingleton<ITelemetryInitializer, Initializer>();
+        services.AddSingleton<ITelemetryModule, Module>();
+        return services;
+    }
+
+    class Module(Lazy<TelemetryClient> telemetry) : ITelemetryModule, IDisposable
+    {
+        ActivityListener? listener;
+
+        public void Initialize(TelemetryConfiguration configuration)
+        {
+            listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+                ActivityStopped = activity =>
+                {
+                    // Basically detects if we have an authenticated user, which are the 
+                    // only type of events we track for now.
+                    if (!telemetry.IsValueCreated)
+                        return;
+
+                    foreach (var ev in activity.Events)
+                    {
+                        var et = new EventTelemetry(ev.Name)
+                        {
+                            Timestamp = ev.Timestamp
+                        };
+
+                        foreach (var item in activity.Baggage.Where(x => !skipProps.Contains(x.Key)))
+                            et.Properties[item.Key] = item.Value;
+
+                        foreach (var item in activity.Tags.Where(x => !skipProps.Contains(x.Key)))
+                            et.Properties[item.Key] = item.Value?.ToString() ?? "";
+
+                        foreach (var item in ev.Tags.Where(x => !skipProps.Contains(x.Key)))
+                            et.Properties[item.Key] = item.Value?.ToString() ?? "";
+
+                        telemetry.Value.TrackEvent(et);
+                    }
+#if DEBUG
+                    // Makes it easier to inspect telemetry in debug mode.
+                    telemetry.Value.Flush();
+#endif
+                },
+            };
+
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        public void Dispose()
+        {
+            listener?.Dispose();
+            telemetry.Value.Flush();
+        }
+    }
+
+    class Middleware(Lazy<TelemetryClient> telemetry) : IFunctionsWorkerMiddleware
+    {
+        public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+        {
+            var request = await context.GetHttpRequestDataAsync();
+            if (request?.Headers.TryGetValues("x-telemetry-id", out var ids) == true &&
+                ids.FirstOrDefault() is { Length: > 0 } id)
+            {
+                // Associate with opaque installation id
+                Activity.Current?.AddBaggage("session_Id", id);
+                telemetry.Value.Context.Session.Id = id;
+            }
+
+            if (request?.Headers.TryGetValues("x-telemetry-operation", out var ops) == true &&
+                ops.FirstOrDefault() is { Length: > 0 } op)
+            {
+                // Associate with opaque installation id
+                Activity.Current?.AddBaggage("operation_Name", op);
+                telemetry.Value.Context.Operation.Name = op;
+            }
+
+            await next(context);
+        }
+    }
+
+    class Initializer : ITelemetryInitializer
+    {
+        public void Initialize(ITelemetry telemetry)
+        {
+            // We don't set the user id for metrics, as they are not tied to a user.
+            if (telemetry is MetricTelemetry)
+                return;
+
+            if (telemetry is ISupportProperties sprops &&
+                sprops.Properties.TryGetValue("session_Id", out var propId))
+            {
+                telemetry.Context.Session.Id = propId;
+                sprops.Properties.Remove("session_Id");
+            }
+            else if (Activity.Current?.GetBaggageItem("session_Id") is { } baggageId)
+            {
+                telemetry.Context.Session.Id = baggageId;
+            }
+
+            if (telemetry is ISupportProperties opprops &&
+                opprops.Properties.TryGetValue("operation_Name", out var propName))
+            {
+                telemetry.Context.Operation.Name = propName;
+                opprops.Properties.Remove("operation_Name");
+            }
+            else if (Activity.Current?.GetBaggageItem("operation_Name") is { } baggageName)
+            {
+                telemetry.Context.Operation.Name = baggageName;
+            }
+        }
+    }
+}

--- a/src/Web/ApplicationVersionTelemetryInitializer.cs
+++ b/src/Web/ApplicationVersionTelemetryInitializer.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Devlooped.Sponsors;
+
+public class ApplicationVersionTelemetryInitializer : ITelemetryInitializer
+{
+    public void Initialize(ITelemetry telemetry) =>
+        telemetry.Context.Component.Version = ThisAssembly.Info.InformationalVersion;
+}

--- a/src/Web/GitHubDeviceFlowAuthentication.cs
+++ b/src/Web/GitHubDeviceFlowAuthentication.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Reflection;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
Modelled after the .NET SDK: https://learn.microsoft.com/en-us/dotnet/core/tools/telemetry.

NOTE: we use a fully non-PII GUID as the "session id", so that no user data is ever used for any telemetry/logging, thus simplifying the GDPR requirements (no need to purge telemetry data which is quite expensive).