### PR TITLE
Switch to using ClaimsIdentity/Subject in token

### DIFF
--- a/src/Core/SponsorableManifest.cs
+++ b/src/Core/SponsorableManifest.cs
@@ -251,16 +251,14 @@ public class SponsorableManifest
             SetDefaultTimesOnTokenCreation = false,
         }.CreateToken(new SecurityTokenDescriptor
         {
-            Claims = tokenClaims.GroupBy(x => x.Type).ToDictionary(
-                x => x.Key,
-                x => x.Count() == 1 ? (object)x.First().Value : x.Select(x => x.Value).ToArray()),
+            Subject = new ClaimsIdentity(tokenClaims),
             IssuedAt = DateTime.UtcNow,
             Expires = expirationDate,
             SigningCredentials = signing,
         });
     }
 
-    public ClaimsPrincipal Validate(string jwt, out SecurityToken? token)
+    public ClaimsIdentity Validate(string jwt, out SecurityToken? token)
     {
         var validation = new TokenValidationParameters
         {
@@ -287,9 +285,9 @@ public class SponsorableManifest
             MapInboundClaims = false,
             SetDefaultTimesOnTokenCreation = false,
         }.ValidateTokenAsync(jwt, validation).Result;
-
+        
         token = result.SecurityToken;
-        return new ClaimsPrincipal(result.ClaimsIdentity);
+        return result.ClaimsIdentity;
     }
 
     /// <summary>

--- a/src/Tests/Signing.cs
+++ b/src/Tests/Signing.cs
@@ -93,9 +93,7 @@ public class Signing(ITestOutputHelper Output)
         {
             Issuer = "https://sponsorlink.devlooped.com/",
             Audience = "devlooped",
-            Claims = claims.GroupBy(x => x.Type).ToDictionary(
-                x => x.Key,
-                x => x.Count() == 1 ? (object)x.First().Value : x.Select(x => x.Value).ToArray()),
+            Subject = new ClaimsIdentity(claims),
             SigningCredentials = signingCredentials,
         });
 

--- a/src/Tests/SponsorManagerTests.cs
+++ b/src/Tests/SponsorManagerTests.cs
@@ -249,11 +249,11 @@ public sealed class SponsorManagerTests : IDisposable
 
         Assert.NotNull(jwt);
 
-        var principal = manifest.Validate(jwt, out var token);
-        Assert.NotNull(principal);
+        var identity = manifest.Validate(jwt, out var token);
+        Assert.NotNull(identity);
         Assert.NotNull(token);
         Assert.Equal(token.Issuer, manifest.Issuer);
-
+        
         var today = DateOnly.FromDateTime(DateTime.UtcNow);
         // Expiration will be the first day of next month.
         var expiry = new DateOnly(today.AddMonths(1).Year, today.AddMonths(1).Month, 1);


### PR DESCRIPTION
Instead of trying to duplicate what the token already does internally with duplicate claims.