### PR TITLE
Add optional endpoint that can emit shields.io endpoint badge data

### DIFF
--- a/src/Core/SponsorLinkOptions.cs
+++ b/src/Core/SponsorLinkOptions.cs
@@ -15,4 +15,14 @@ public class SponsorLinkOptions
     /// Optional private key to sign SponsorLink manifests.
     /// </summary>
     public string? PrivateKey { get; init; }
+
+    /// <summary>
+    /// Timespan for the expiration of the sponsorable manifest, in a format compatible with <see cref="TimeSpan.Parse(string)"/>.
+    /// </summary>
+    public string? ManifestExpiration { get; init; }
+
+    /// <summary>
+    /// Timespan for the expiration of the badge cache, in a format compatible with <see cref="TimeSpan.Parse(string)"/>.
+    /// </summary>
+    public string? BadgeExpiration { get; init; }
 }

--- a/src/Core/SponsorsManager.cs
+++ b/src/Core/SponsorsManager.cs
@@ -54,15 +54,10 @@ public partial class SponsorsManager(
             if (account.Login != manifest.Sponsorable)
                 throw new InvalidOperationException("Manifest sponsorable account does not match configured sponsorable account.");
 
-            jwt = cache.Set(JwtCacheKey, jwt, new MemoryCacheEntryOptions
-            {
-                AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)
-            });
+            var cacheExpiration = TimeSpan.TryParse(options.BadgeExpiration, out var expiration) ? expiration : TimeSpan.FromHours(1);
 
-            manifest = cache.Set(ManifestCacheKey, manifest, new MemoryCacheEntryOptions
-            {
-                AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)
-            });
+            jwt = cache.Set(JwtCacheKey, jwt, cacheExpiration);
+            manifest = cache.Set(ManifestCacheKey, manifest, cacheExpiration);
 
             Activity.Current?.AddEvent(new ActivityEvent("Sponsorable.ManifestRead",
                 tags: new ActivityTagsCollection([KeyValuePair.Create<string, object?>("sponsorable", manifest.Sponsorable)])));

--- a/src/Web/Badge.cs
+++ b/src/Web/Badge.cs
@@ -1,0 +1,94 @@
+﻿using Azure.Core;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.Functions.Worker;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.Azure.Functions.Worker.Http;
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace Devlooped.Sponsors;
+
+public class Badge(IConfiguration config, IHttpClientFactory httpFactory, IMemoryCache cache, IOptions<SponsorLinkOptions> options, ILogger<Badge> logger)
+{
+    SponsorLinkOptions options = options.Value;
+    TimeSpan expiration = TimeSpan.TryParse(options.Value.BadgeExpiration, out var expiration) ? expiration : TimeSpan.FromMinutes(5);
+
+    // Optional endpoint that uses SponsorLink:LogAnalytics workspace ID to query for usage stats
+    // In a format compatible with shields.io badges.
+    [Function("badge")]
+    public async Task<HttpResponseData> RunAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequestData req)
+    {
+        var workspace = config["SponsorLink:LogsAnalytics"];
+        if (string.IsNullOrEmpty(workspace))
+        {
+            logger.LogError("Missing SponsorLink:LogsAnalytics configuration");
+            return req.CreateResponse(HttpStatusCode.InternalServerError);
+        }
+
+        var type = req.Query.AllKeys.FirstOrDefault() ?? nameof(SponsorTypes.User);
+        // Account for abbreviations
+        type = type switch
+        {
+            "org" => nameof(SponsorTypes.Organization),
+            "contrib" => nameof(SponsorTypes.Contributor),
+            _ => type
+        };
+
+        if (!Enum.TryParse<SponsorTypes>(type, true, out var typed))
+        {
+            logger.LogError("Invalid sponsor type: {type}", type);
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        var cacheKey = "Badge." + typed;
+
+        if (!cache.TryGetValue<JObject>(cacheKey, out var stats) || stats is null)
+        {
+            var token = await new DefaultAzureCredential().GetTokenAsync(new TokenRequestContext(["https://api.loganalytics.io/.default"]));
+            using var http = httpFactory.CreateClient();
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+
+            var response = await http.GetAsync($"https://api.loganalytics.io/v1/workspaces/{workspace}/query?query=" +
+                $"""
+                AppEvents
+                | union AppRequests
+                | where isnotempty(SessionId) // and SessionId != 'devlooped.sponsors.ci'
+                | where Name == "Sponsor.Lookup"
+                | extend Sponsor = tostring(Properties['Type'])
+                | summarize arg_max(Sponsor, *) by SessionId
+                | extend Types = parse_csv(Sponsor)
+                | mv-expand Types
+                | where Types contains '{typed}'
+                | summarize Count = count() by tostring(Types)
+                | summarize Total = sum(Count)
+                """);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError("Failed to query for badge stats: {status}", response.StatusCode);
+                return req.CreateResponse(HttpStatusCode.InternalServerError);
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            stats = JObject.Parse(json);
+            cache.Set(cacheKey, stats, expiration);
+        }
+
+        var output = req.CreateResponse(HttpStatusCode.OK);
+        // Also cache downstream (specifically shields.io)
+        output.Headers.Add("Cache-Control", "public,max-age=" + expiration.TotalSeconds);
+        await output.WriteAsJsonAsync(new
+        {
+            schemaVersion = 1,
+            label = typed.ToString(),
+            message = stats.SelectToken("$.tables[0].rows[0][0]")?.ToString() ?? "0",
+        });
+
+        return output;
+    }
+}


### PR DESCRIPTION
Usage: `/badge?[user|org|contrib|team]`. Provides just minimal data (label + value) that can all be overriden on the badge configuration side. See https://shields.io/badges/endpoint-badge.

Badge example:

https://img.shields.io/endpoint?color=blue&url=https://sponsorlink.devlooped.com/badge?user

Renders (direct) user sponsors that have sync'ed using SponsorLink.