### PR TITLE
Allow disabling Info diagnostics globally

### DIFF
--- a/samples/dotnet/SponsorLink/SponsorLinkAnalyzer.cs
+++ b/samples/dotnet/SponsorLink/SponsorLinkAnalyzer.cs
@@ -43,6 +43,12 @@ public class SponsorLinkAnalyzer : DiagnosticAnalyzer
                 // multiple diagnostics for each project in a solution that uses the same product.
                 ctx.RegisterCompilationEndAction(ctx =>
                 {
+                    // We'd never report Info/hero link if users opted out of it.
+                    if (status == SponsorStatus.Sponsor &&
+                        ctx.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue("build_property.SponsorLinkHero", out var slHero) &&
+                        bool.TryParse(slHero, out var isHero) && isHero)
+                        return;
+
                     // Only report if the package is directly referenced in the project for
                     // any of the funding packages we monitor (i.e. we could have one or more
                     // metapackages we also consider "direct references).

--- a/samples/dotnet/SponsorLink/buildTransitive/Devlooped.Sponsors.targets
+++ b/samples/dotnet/SponsorLink/buildTransitive/Devlooped.Sponsors.targets
@@ -26,6 +26,9 @@
 
     <!-- To quickly exit if true -->
     <CompilerVisibleProperty Include="DesignTimeBuild" />
+
+    <!-- If the user declares himself already as a hero, we don't need to remind him via Info diagnostics -->
+    <CompilerVisibleProperty Include="SponsorLinkHero" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
If you declare via a property you already know you're a SL hero, we have no need to remind you :).

```xml
<SponsorLinkHero>true</SponsorLinkHero>
```

This will disable the info diagnostics and decrease the noise for sponsors after synchronizing their manifests.