### PR TITLE
Add GitHub webhook for auto-labeling of sponsor issues

### DIFF
--- a/src/Core/HttpGraphQueryClient.cs
+++ b/src/Core/HttpGraphQueryClient.cs
@@ -113,7 +113,11 @@ public class HttpGraphQueryClient(IHttpClientFactory factory, string name) : IGr
             if (typed is IEnumerable<object> array)
                 items.AddRange(array);
 
-            info = JsonSerializer.Deserialize<PageInfo>(await JQ.ExecuteAsync(raw, ".. | .pageInfo? | values"), JsonOptions.Default);
+            var pageInfoRaw = await JQ.ExecuteAsync(raw, ".. | .pageInfo? | values");
+            if (string.IsNullOrEmpty(pageInfoRaw))
+                break;
+
+            info = JsonSerializer.Deserialize<PageInfo>(pageInfoRaw, JsonOptions.Default);
             if (info is null || !info.HasNextPage)
                 break;
         }

--- a/src/Core/JsonOptions.cs
+++ b/src/Core/JsonOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -15,6 +16,7 @@ static partial class JsonOptions
         new()
 #endif
         {
+            //Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             AllowTrailingCommas = true,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             ReadCommentHandling = JsonCommentHandling.Skip,

--- a/src/Core/Pushover.cs
+++ b/src/Core/Pushover.cs
@@ -1,0 +1,159 @@
+﻿using System.Diagnostics;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+
+namespace Devlooped.Sponsors;
+
+public interface IPushover
+{
+    Task PostAsync(PushoverMessage message);
+}
+
+public class PushoverOptions
+{
+    public string? Token { get; set; }
+    public string? Key { get; set; }
+
+    public PushoverPriority IssuePriority { get; set; } = PushoverPriority.High;
+    public PushoverPriority IssueCommentPriority { get; set; } = PushoverPriority.High;
+}
+
+
+public enum PushoverPriority
+{
+    Lowest = -2,
+    Low = -1,
+    Normal = 0,
+    High = 1,
+    Emergency = 2
+}
+
+public class PushoverMessage
+{
+    /// <summary>
+    /// The message's title, otherwise the app's name is used
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// The message to send.
+    /// </summary>
+    public string? Message { get; set; }
+
+    /// <summary>
+    ///  An image attachment to send with the message.
+    /// </summary>
+    public string? Attachment { get; set; }
+
+    /// <summary>
+    /// A supplementary URL to show with the message
+    /// </summary>
+    public string? Url { get; set; }
+
+    /// <summary>
+    /// A title for the supplementary URL, otherwise just the URL is shown
+    /// </summary>
+    [JsonPropertyName("url_title")]
+    public string? UrlTitle { get; set; }
+
+    /// <summary>
+    /// The priority of the message
+    /// </summary>
+    public PushoverPriority Priority { get; set; } = PushoverPriority.Normal;
+
+    /// <summary>
+    /// The name of the sound to use with 
+    /// </summary>
+    public string Sound { get; set; } = "pushover";
+
+    public PushoverMessage() { }
+
+    public PushoverMessage(string message) => Message = message;
+}
+
+public static class PushoverSounds
+{
+    /// <summary>Pushover (default)</summary>
+    public const string Pushover = "pushover";
+    /// <summary>Bike</summary>
+    public const string Bike = "bike";
+    /// <summary>Bugle</summary>
+    public const string Bugle = "bugle";
+    /// <summary>Cash Register</summary>
+    public const string Cashregister = "cashregister";
+    /// <summary>Classical</summary>
+    public const string Classical = "classical";
+    /// <summary>Cosmic</summary>
+    public const string Cosmic = "cosmic";
+    /// <summary>Falling</summary>
+    public const string Falling = "falling";
+    /// <summary>Gamelan</summary>
+    public const string Gamelan = "gamelan";
+    /// <summary>Incoming</summary>
+    public const string Incoming = "incoming";
+    /// <summary>Intermission</summary>
+    public const string Intermission = "intermission";
+    /// <summary>Magic</summary>
+    public const string Magic = "magic";
+    /// <summary>Mechanical</summary>
+    public const string Mechanical = "mechanical";
+    /// <summary>Piano Bar</summary>
+    public const string Pianobar = "pianobar";
+    /// <summary>Siren</summary>
+    public const string Siren = "siren";
+    /// <summary>Space Alarm</summary>
+    public const string Spacealarm = "spacealarm";
+    /// <summary>Tug Boat</summary>
+    public const string Tugboat = "tugboat";
+    /// <summary>Alien Alarm (long)</summary>
+    public const string Alien = "alien";
+    /// <summary>Climb (long)</summary>
+    public const string Climb = "climb";
+    /// <summary>Persistent (long)</summary>
+    public const string Persistent = "persistent";
+    /// <summary>Pushover Echo (long)</summary>
+    public const string Echo = "echo";
+    /// <summary>Up Down (long)</summary>
+    public const string Updown = "updown";
+    /// <summary>Vibrate Only</summary>
+    public const string Vibrate = "vibrate";
+    /// <summary>None (silent)</summary>
+    public const string None = "none";
+}
+
+public class Pushover(IHttpClientFactory factory, IOptions<PushoverOptions> options) : IPushover
+{
+    static JsonSerializerOptions json = new(JsonSerializerDefaults.Web)
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault | JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = true,
+            //Converters =
+            //{
+            //    new JsonStringEnumConverter(allowIntegerValues: false),
+            //}
+        };
+
+    readonly PushoverOptions options = options.Value;
+
+    public async Task PostAsync(PushoverMessage message)
+    {
+        if (options.Token == null || options.Key == null)
+            return;
+
+        using var http = factory.CreateClient();
+
+        var node = JsonNode.Parse(JsonSerializer.Serialize(message, json));
+        Debug.Assert(node != null);
+
+        node["token"] = options.Token;
+        node["user"] = options.Key;
+
+        var response = await http.PostAsJsonAsync("https://api.pushover.net/1/messages.json", node);
+
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Core/Records.cs
+++ b/src/Core/Records.cs
@@ -20,7 +20,12 @@ public record Sponsorship(string Sponsorable, [property: Browsable(false)] strin
 #endif
     [property: DisplayName("One-time")] bool OneTime);
 
-public record Tier(string Name, string Description, int Amount, bool OneTime)
+public record Sponsor(string Login, AccountType Type, Tier Tier)
+{
+    public SponsorTypes Kind { get; init; } = Type == AccountType.Organization ? SponsorTypes.Organization : SponsorTypes.User;
+}
+
+public record Tier(string Id, string Name, string Description, int Amount, bool OneTime, string? Previous = null)
 {
     public Dictionary<string, string> Meta { get; init; } = [];
 }

--- a/src/Tests/Attributes.cs
+++ b/src/Tests/Attributes.cs
@@ -40,6 +40,27 @@ public class CIFactAttribute : FactAttribute
     }
 }
 
+public class SecretsTheoryAttribute : TheoryAttribute
+{
+    public SecretsTheoryAttribute(params string[] secrets)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddUserSecrets<SecretsTheoryAttribute>()
+            .Build();
+
+        var missing = new HashSet<string>();
+
+        foreach (var secret in secrets)
+        {
+            if (string.IsNullOrEmpty(configuration[secret]))
+                missing.Add(secret);
+        }
+
+        if (missing.Count > 0)
+            Skip = "Missing user secrets: " + string.Join(',', missing);
+    }
+}
+
 public class LocalTheoryAttribute : TheoryAttribute
 {
     public LocalTheoryAttribute()

--- a/src/Tests/GraphQueriesTests.cs
+++ b/src/Tests/GraphQueriesTests.cs
@@ -512,6 +512,19 @@ public class GraphQueriesTests(ITestOutputHelper output)
         Assert.Equal(httpdata, clidata);
     }
 
+    [SecretsFact("SponsorLink:Account", "GitHub:Token")]
+    public async Task GetAllSponsors()
+    {
+        var client = new HttpGraphQueryClient(Services.GetRequiredService<IHttpClientFactory>(), "GitHub:Token");
+
+        var sponsors = await client.QueryAsync(GraphQueries.Sponsors(Helpers.Configuration["SponsorLink:Account"]!));
+
+        Assert.NotNull(sponsors);
+        Assert.NotEmpty(sponsors);
+        Assert.All(sponsors, x => Assert.NotNull(x.Login));
+        Assert.All(sponsors, x => Assert.NotNull(x.Tier));
+    }
+
     void EnsureAuthenticated(string secret = "GitHub:Token")
     {
         Assert.True(TryExecute("gh", "auth login --with-token", Configuration[secret]!, out var output));

--- a/src/Tests/Misc.cs
+++ b/src/Tests/Misc.cs
@@ -79,6 +79,23 @@ public class Misc(ITestOutputHelper output)
 
     record PurgeStatus(string status);
 
+    [SecretsFact("Pushover:Token", "Pushover:Key")]
+    public async Task PushMessage()
+    {
+        var options = new PushoverOptions();
+        Configuration.Bind("Pushover", options);
+        var pushover = new Pushover(Services.GetRequiredService<IHttpClientFactory>(), Options.Create(options));
+
+        await pushover.PostAsync(new PushoverMessage
+        {
+            Title = $"🐛 by kzu as Silver sponsor",
+            Message = "Add optional endpoint that can emit shields endpoint badge data",
+            Url = "https://github.com/devlooped/SponsorLink/pull/258",
+            UrlTitle = $"View Issue #{258}",
+            Priority = PushoverPriority.High
+        });
+    }
+
     public static void SponsorsAscii()
     {
         var heart =

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -5,7 +5,7 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <RootNamespace>Devlooped.Tests</RootNamespace>
     <!-- IVT+ThisAssembly -->
-    <NoWarn>CS0436;CS0435;NU1701</NoWarn>
+    <NoWarn>CS0436;CS0435;NU1701;RS1036;RS2008</NoWarn>
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>

--- a/src/Web/ConfigurationExtensions.cs
+++ b/src/Web/ConfigurationExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+
+namespace Devlooped.Sponsors;
+
+public static class ConfigurationExtensions
+{
+    public static IConfigurationBuilder Configure(this IConfigurationBuilder builder)
+    {
+        builder.AddUserSecrets("A85AC898-E41C-4D9D-AD9B-52ED748D9901");
+        // Optionally, use key vault for secrets instead of plain-text app service configuration
+        if (Environment.GetEnvironmentVariable("AZURE_KEYVAULT") is string kv)
+            builder.AddAzureKeyVault(new Uri($"https://{kv}.vault.azure.net/"), new DefaultAzureCredential());
+
+#if DEBUG
+        // Allows using SL config for local development. 
+        // In particular, the telemetry module will inject the local id as if had been received from 'x-telemetry-id' header 
+        // when testing locally via the browser for easier API testing.
+        builder.AddDotNetConfig(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".sponsorlink"));
+#endif
+
+        return builder;
+    }
+}

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -1,6 +1,5 @@
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
-using Azure.Identity;
 using Devlooped.Sponsors;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -10,105 +9,97 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.JsonWebTokens;
+using Octokit.Webhooks;
+using Octokit.Webhooks.AzureFunctions;
 
-class Program
-{
-    static void Main(string[] args)
+var host = new HostBuilder()
+    .ConfigureAppConfiguration(builder => builder.Configure())
+    .ConfigureFunctionsWebApplication(builder =>
     {
-        var host = new HostBuilder()
-            .ConfigureAppConfiguration(builder =>
-            {
-                builder.AddUserSecrets("A85AC898-E41C-4D9D-AD9B-52ED748D9901");
-                // Optionally, use key vault for secrets instead of plain-text app service configuration
-                if (Environment.GetEnvironmentVariable("AZURE_KEYVAULT") is string kv)
-                    builder.AddAzureKeyVault(new Uri($"https://{kv}.vault.azure.net/"), new DefaultAzureCredential());
-
+        builder.UseFunctionContextAccessor();
+        builder.UseErrorLogging();
 #if DEBUG
-                // Allows using SL config for local development. 
-                // In particular, the telemetry module will inject the local id as if had been received from 'x-telemetry-id' header 
-                // when testing locally via the browser for easier API testing.
-                builder.AddDotNetConfig(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".sponsorlink"));
+        builder.UseGitHubDeviceFlowAuthentication();
 #endif
-            })
-            .ConfigureFunctionsWebApplication(builder =>
+        builder.UseAppServiceAuthentication();
+        builder.UseGitHubAuthentication(populateEmails: true, verifiedOnly: true);
+        builder.UseClaimsPrincipal();
+        builder.UseActivityTelemetry();
+    })
+    .ConfigureServices(services =>
+    {
+        // Register first so it initializes always before every other initializer.
+        services.AddSingleton<ITelemetryInitializer, ApplicationVersionTelemetryInitializer>();
+
+        services.AddApplicationInsightsTelemetryWorkerService();
+        services.ConfigureFunctionsApplicationInsights();
+        services.AddActivityTelemetry();
+
+        services.AddMemoryCache();
+        services.AddOptions();
+        services.AddSingleton<Lazy<TelemetryClient>, Lazy<TelemetryClient>>(sp => new(() => sp.GetRequiredService<TelemetryClient>()));
+
+        JsonWebTokenHandler.DefaultMapInboundClaims = false;
+
+        services
+            .AddOptions<SponsorLinkOptions>()
+            .Configure<IConfiguration>((options, configuration) =>
             {
-                builder.UseFunctionContextAccessor();
-                builder.UseErrorLogging();
-#if DEBUG
-                builder.UseGitHubDeviceFlowAuthentication();
-#endif
-                builder.UseAppServiceAuthentication();
-                builder.UseGitHubAuthentication(populateEmails: true, verifiedOnly: true);
-                builder.UseClaimsPrincipal();
-                builder.UseActivityTelemetry();
-            })
-            .ConfigureServices(services =>
+                configuration.GetSection("SponsorLink").Bind(options);
+            });
+
+        services.AddOptions<PushoverOptions>()
+            .Configure<IConfiguration>((options, configuration) =>
             {
-                // Register first so it initializes always before every other initializer.
-                services.AddSingleton<ITelemetryInitializer, ApplicationVersionTelemetryInitializer>();
+                configuration.GetSection("Pushover").Bind(options);
+            });
 
-                services.AddApplicationInsightsTelemetryWorkerService();
-                services.ConfigureFunctionsApplicationInsights();
-                services.AddActivityTelemetry();
+        services.AddHttpClient().ConfigureHttpClientDefaults(defaults => defaults.ConfigureHttpClient(http =>
+        {
+            http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ThisAssembly.Info.Product, ThisAssembly.Info.InformationalVersion));
+        }));
 
-                services.AddMemoryCache();
-                services.AddOptions();
-                services.AddSingleton<Lazy<TelemetryClient>, Lazy<TelemetryClient>>(sp => new(() => sp.GetRequiredService<TelemetryClient>()));
+        // Add sponsorable client using the GH_TOKEN for GitHub API access
+        services.AddHttpClient("sponsorable", (sp, http) =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            if (config["GitHub:Token"] is not { Length: > 0 } ghtoken)
+                throw new InvalidOperationException("Missing required configuration 'GitHub:Token'");
 
-                JsonWebTokenHandler.DefaultMapInboundClaims = false;
+            http.BaseAddress = new Uri("https://api.github.com");
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ghtoken);
+        });
 
-                services
-                    .AddOptions<SponsorLinkOptions>()
-                    .Configure<IConfiguration>((options, configuration) =>
-                    {
-                        configuration.GetSection("SponsorLink").Bind(options);
-                    });
+        // Add sponsor client using the current invocation claims for GitHub API access
+        services.AddScoped<AccessTokenMessageHandler>();
+        services.AddHttpClient("sponsor", http =>
+        {
+            http.BaseAddress = new Uri("https://api.github.com");
+        }).AddHttpMessageHandler<AccessTokenMessageHandler>();
 
-                services.AddHttpClient().ConfigureHttpClientDefaults(defaults => defaults.ConfigureHttpClient(http =>
-                {
-                    http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ThisAssembly.Info.Product, ThisAssembly.Info.InformationalVersion));
-                }));
+        services.AddGraphQueryClient();
 
-                // Add sponsorable client using the GH_TOKEN for GitHub API access
-                services.AddHttpClient("sponsorable", (sp, http) =>
-                {
-                    var config = sp.GetRequiredService<IConfiguration>();
-                    if (config["GitHub:Token"] is not { Length: > 0 } ghtoken)
-                        throw new InvalidOperationException("Missing required configuration 'GitHub:Token'");
+        // RSA key for JWT signing
+        services.AddSingleton(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<SponsorLinkOptions>>();
+            if (string.IsNullOrEmpty(options.Value.PrivateKey))
+                throw new InvalidOperationException($"Missing required configuration 'SponsorLink:{nameof(SponsorLinkOptions.PrivateKey)}'");
 
-                    http.BaseAddress = new Uri("https://api.github.com");
-                    http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", ghtoken);
-                });
+            // The key (as well as the yaml manifest) can be generated using sponsors init
+            // Install with: gh extension install devlooped/gh-sponsors
+            // See: https://github.com/devlooped/gh-sponsors
+            var rsa = RSA.Create();
+            rsa.ImportRSAPrivateKey(Convert.FromBase64String(options.Value.PrivateKey), out _);
 
-                // Add sponsor client using the current invocation claims for GitHub API access
-                services.AddScoped<AccessTokenMessageHandler>();
-                services.AddHttpClient("sponsor", http =>
-                {
-                    http.BaseAddress = new Uri("https://api.github.com");
-                }).AddHttpMessageHandler<AccessTokenMessageHandler>();
+            return rsa;
+        });
 
-                services.AddGraphQueryClient();
+        services.AddSingleton<SponsorsManager>();
+        services.AddSingleton<WebhookEventProcessor, Webhook>();
+        services.AddSingleton<IPushover, Pushover>();
+    })
+    .ConfigureGitHubWebhooks(new ConfigurationBuilder().Configure().Build()["GitHub:Secret"])
+    .Build();
 
-                // RSA key for JWT signing
-                services.AddSingleton(sp =>
-                {
-                    var options = sp.GetRequiredService<IOptions<SponsorLinkOptions>>();
-                    if (string.IsNullOrEmpty(options.Value.PrivateKey))
-                        throw new InvalidOperationException($"Missing required configuration 'SponsorLink:{nameof(SponsorLinkOptions.PrivateKey)}'");
-
-                    // The key (as well as the yaml manifest) can be generated using sponsors init
-                    // Install with: gh extension install devlooped/gh-sponsors
-                    // See: https://github.com/devlooped/gh-sponsors
-                    var rsa = RSA.Create();
-                    rsa.ImportRSAPrivateKey(Convert.FromBase64String(options.Value.PrivateKey), out _);
-
-                    return rsa;
-                });
-
-                services.AddSingleton<SponsorsManager>();
-            })
-            .Build();
-
-        host.Run();
-    }
-}
+host.Run();

--- a/src/Web/SponsorLink.Legacy.cs
+++ b/src/Web/SponsorLink.Legacy.cs
@@ -10,4 +10,11 @@ partial class SponsorLink
     [Function("legacy-sync")]
     public static IActionResult LegacySyncAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "sync")] HttpRequest req)
         => new RedirectResult("me", true, true);
+
+    /// <summary>
+    /// Backwards compatibility for pre-beta endpoint.
+    /// </summary>
+    [Function("legacy-user")]
+    public static IActionResult LegacyUserAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "user")] HttpRequest req)
+        => new RedirectResult("view", true, true);
 }

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -20,11 +20,13 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.5.0" PrivateAssets="all" />
     <PackageReference Include="CliWrap" Version="3.6.6" />
+    <PackageReference Include="Octokit.Webhooks.AzureFunctions" Version="2.2.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/src/Web/Webhook.cs
+++ b/src/Web/Webhook.cs
@@ -1,0 +1,123 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+using Octokit;
+using Octokit.Webhooks;
+using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.IssueComment;
+using Octokit.Webhooks.Events.Issues;
+using Octokit.Webhooks.Events.Sponsorship;
+
+namespace Devlooped.Sponsors;
+
+public class Webhook(SponsorsManager manager, IConfiguration config, IPushover notifier) : WebhookEventProcessor
+{
+    static ActivitySource tracer = ActivityTracer.Source;
+
+    protected override async Task ProcessSponsorshipWebhookAsync(WebhookHeaders headers, SponsorshipEvent payload, SponsorshipAction action)
+    {
+        using var activity = tracer.StartActivity("Sponsorship" + action);
+        activity?.AddEvent(new ActivityEvent(action));
+        manager.RefreshSponsors();
+        await base.ProcessSponsorshipWebhookAsync(headers, payload, action);
+    }
+
+    protected override async Task ProcessIssueCommentWebhookAsync(WebhookHeaders headers, IssueCommentEvent payload, IssueCommentAction action)
+    {
+        using var activity = tracer.StartActivity("IssueComment");
+        activity?.AddEvent(new ActivityEvent(action));
+
+        activity?.SetTag("sender", payload.Sender?.Login);
+        activity?.SetTag("repo", payload.Repository?.FullName);
+        activity?.SetTag("issue", payload.Issue.Number.ToString());
+        activity?.SetTag("comment", payload.Comment.Id.ToString());
+
+        if (await manager.FindSponsorAsync(payload.Sender?.Login) is { } sponsor && sponsor.Kind != SponsorTypes.Team)
+        {
+            if (sponsor.Tier.Meta.TryGetValue("tier", out var tier))
+                activity?.SetTag("sponsor", tier);
+            else
+                activity?.SetTag("sponsor", "sponsor");
+
+            if (action == IssueCommentAction.Created || action == IssueCommentAction.Edited)
+            {
+                await notifier.PostAsync(new PushoverMessage
+                {
+                    Title = $"🗨️ by {payload.Sender?.Login} as {CultureInfo.InvariantCulture.TextInfo.ToTitleCase(tier ?? "")} sponsor",
+                    Message = payload.Comment.Body,
+                    Url = payload.Comment.Url,
+                    UrlTitle = $"View comment on issue #{payload.Issue.Number}",
+                    Priority = PushoverPriority.High
+                });
+            }
+        }
+
+        await base.ProcessIssueCommentWebhookAsync(headers, payload, action);
+    }
+
+    protected override async Task ProcessIssuesWebhookAsync(WebhookHeaders headers, IssuesEvent payload, IssuesAction action)
+    {
+        await base.ProcessIssuesWebhookAsync(headers, payload, action);
+
+        using var activity = tracer.StartActivity();
+        activity?.AddEvent(new ActivityEvent(action));
+
+        activity?.SetTag("sender", payload.Sender?.Login);
+        activity?.SetTag("repo", payload.Repository?.FullName);
+        activity?.SetTag("issue", payload.Issue.Number.ToString());
+
+        if (await manager.FindSponsorAsync(payload.Sender?.Login) is { } sponsor && sponsor.Kind != SponsorTypes.Team)
+        {
+            if (sponsor.Tier.Meta.TryGetValue("tier", out var tier))
+                activity?.SetTag("sponsor", tier);
+            else
+                activity?.SetTag("sponsor", "sponsor");
+
+            if (!sponsor.Tier.Meta.TryGetValue("label", out var label))
+                label = "sponsor 💜";
+            if (!sponsor.Tier.Meta.TryGetValue("color", out var color))
+                color = "#D4C5F9";
+
+            // ensure Issue has the given label applied
+            if (action == IssuesAction.Opened ||
+                action == IssuesAction.Edited ||
+                action == IssuesAction.Reopened ||
+                action == IssuesAction.Transferred)
+            {
+                if (config["GitHub:Token"] is not { } ghtoken ||
+                    payload.Issue.Labels.Any(x => x.Name == label) ||
+                    payload.Repository is null)
+                    return;
+
+                var client = new GitHubClient(new ProductHeaderValue(ThisAssembly.Info.Product, ThisAssembly.Info.InformationalVersion))
+                {
+                    Credentials = new Credentials(config["GitHub:Token"])
+                };
+
+                var definition = await client.Issue.Labels.Get(payload.Repository.Id, label);
+                if (definition == null)
+                {
+                    await client.Issue.Labels.Create(payload.Repository.Owner.Login, payload.Repository.Name, new NewLabel(label, color) 
+                    { 
+                        Description = sponsor.Kind == SponsorTypes.Contributor ?
+                            "Sponsor via contributions" :
+                            tier != null ? 
+                            $"{CultureInfo.InvariantCulture.TextInfo.ToTitleCase(tier)} Sponsor" : 
+                            "Sponsor"
+                    });
+                }
+
+                await client.Issue.Labels.AddToIssue(payload.Repository.Owner.Login, payload.Repository.Name, (int)payload.Issue.Number, [label]);
+
+                await notifier.PostAsync(new PushoverMessage
+                {
+                    Title = $"🐛 by {payload.Sender?.Login} as {CultureInfo.InvariantCulture.TextInfo.ToTitleCase(tier ?? "")} sponsor",
+                    Message = payload.Issue.Title,
+                    Url = payload.Issue.Url,
+                    UrlTitle = $"View Issue #{payload.Issue.Number}",
+                    Priority = PushoverPriority.High
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Auto-labeling works by configuring a webhook (at repo or organization level). The optional `GitHub:Secret` configration can be used to secure the webhook callback, but it's not required (although recommended). The endpoint is `github/webhooks` and should be set to receive `application/json` content type.

Currently, the webhook callback only processes sponsorship changes (to refresh the cached list of sponsors), issues and issue comments. Issue actions result in auto-labeling.

Labels for sponsors of certain tiers can be configured via yaml metadata in the tier description, like:

```
☕ You want to buy me a Nespresso capsule, and everyone should be allowed to do that 🤗
<!--
tier: basic
label: sponsor 💜
color: #D4C5F9
-->
```

Tiers inherit metadata from lower tiers so you don't have to repeat them.

Also optionally introduce pushover-based notifications (for issue and issue comment actions), if the following secrets are configured:

- `PushOver:Token`: the API key/token
- `PushOver:Key`: the user or delivery group key

See https://pushover.net/api for more info on that.