### PR TITLE
Make the funding help url configurable via MSBuild

### DIFF
--- a/samples/dotnet/Analyzer/Analyzer.csproj
+++ b/samples/dotnet/Analyzer/Analyzer.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.4.3" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Git" Version="1.4.3" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Constants" Version="1.4.3" PrivateAssets="all" />
-    <PackageReference Include="ThisAssembly.Strings" Version="1.4.3" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly.Project" Version="1.4.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/samples/dotnet/SponsorLink.Analyzer.targets
+++ b/samples/dotnet/SponsorLink.Analyzer.targets
@@ -20,10 +20,12 @@
     <FundingPrefix Condition="'$(FundingPrefix)' == ''">$([System.Text.RegularExpressions.Regex]::Replace("$(FundingProduct)", "[^A-Z]", ""))</FundingPrefix>
     <!-- Default grace days for an expired sponsor manifest or unknown status -->
     <FundingGrace Condition="'$(FundingGrace)' == ''">15</FundingGrace>
+    <!-- Url to use as the helpUrl in diagnostics, to learn more about SL -->
+    <FundingHelpUrl Condition="'$(FundingHelpUrl)' == ''">https://github.com/devlooped#sponsorlink</FundingHelpUrl>
 
     <!-- Strong-naming analyzers is both unnecessary and additionally unsupported by ILRepack when run as a dotnet tool -->
     <SignAssembly Condition="'$(MergeAnalyzerAssemblies)' == 'true'">false</SignAssembly>
-</PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)SponsorLink/*.cs"
@@ -123,6 +125,7 @@ partial class SponsorLink
         public static HashSet&lt;string&gt; PackageIds { get%3B } = [$(_FundingPackageIds)]%3B
         public const string Product = "$(FundingProduct)"%3B
         public const string Prefix = "$(FundingPrefix)"%3B
+        public const string HelpUrl = "$(FundingHelpUrl)"%3B
         public const int Grace = $(FundingGrace)%3B
     }
 }

--- a/samples/dotnet/SponsorLink/DiagnosticsManager.cs
+++ b/samples/dotnet/SponsorLink/DiagnosticsManager.cs
@@ -202,7 +202,7 @@ class DiagnosticsManager
         description: string.Format(CultureInfo.CurrentCulture, Resources.Unknown_Description,
             string.Join(", ", sponsorable.Select(x => $"https://github.com/sponsors/{x}")),
             string.Join(" ", sponsorable.Select(x => "@" + x))),
-        helpLinkUri: "https://github.com/devlooped#sponsorlink",
+        helpLinkUri: Funding.HelpUrl,
         WellKnownDiagnosticTags.NotConfigurable, "CompilationEnd");
 
     internal static DiagnosticDescriptor CreateExpiring(string[] sponsorable, string prefix) => new(
@@ -235,7 +235,7 @@ class DiagnosticsManager
             hidden ? DiagnosticSeverity.Hidden : DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: Resources.Sponsor_Description,
-            helpLinkUri: "https://github.com/devlooped#sponsorlink",
+            helpLinkUri: Funding.HelpUrl,
             "DoesNotSupportF1Help", "CompilationEnd");
 
     internal static DiagnosticDescriptor CreateContributor(string[] sponsorable, string prefix, bool hidden = false) => new(
@@ -246,6 +246,6 @@ class DiagnosticsManager
             hidden ? DiagnosticSeverity.Hidden : DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: Resources.Contributor_Description,
-            helpLinkUri: "https://github.com/devlooped#sponsorlink",
+            helpLinkUri: Funding.HelpUrl,
             "DoesNotSupportF1Help", "CompilationEnd");
 }

--- a/samples/dotnet/SponsorLink/SponsorLink.csproj
+++ b/samples/dotnet/SponsorLink/SponsorLink.csproj
@@ -32,7 +32,7 @@
   <ItemGroup>
     <EmbeddedResource Update="Resources.es-AR.resx" ManifestResourceName="Devlooped.Sponsors.%(Filename)" />
     <EmbeddedResource Update="Resources.es.resx" ManifestResourceName="Devlooped.Sponsors.%(Filename)" />
-    <EmbeddedResource Update="Resources.resx" ManifestResourceName="Devlooped.Sponsors.%(Filename)" StronglyTypedManifestPrefix="Devlooped.Sponsors" StronglyTypedClassName="%(Filename)" StronglyTypedNamespace="Devlooped.Sponsors" StronglyTypedLanguage="$(Language)" />
+    <EmbeddedResource Update="Resources.resx" Type="Resx" ManifestResourceName="Devlooped.Sponsors.%(Filename)" StronglyTypedManifestPrefix="Devlooped.Sponsors" StronglyTypedClassName="%(Filename)" StronglyTypedNamespace="Devlooped.Sponsors" StronglyTypedLanguage="$(Language)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -68,6 +68,7 @@ partial class SponsorLink
         public static HashSet&lt;string&gt; PackageIds { get%3B } = [$(_FundingPackageIds)]%3B
         public const string Product = "$(FundingProduct)"%3B
         public const string Prefix = "$(FundingPrefix)"%3B
+        public const string HelpUrl = "$(FundingHelpUrl)"%3B
         public const int Grace = $(FundingGrace)%3B
     }
 }


### PR DESCRIPTION
`$(FundingHelpUrl)` becomes `Funding.HelpUrl` for use in code when reporting diagnostics or messages.