### PR TITLE
Add overload to simplify getting or setting status

### DIFF
--- a/samples/dotnet/Analyzer/StatusReportingGenerator.cs
+++ b/samples/dotnet/Analyzer/StatusReportingGenerator.cs
@@ -12,15 +12,14 @@ public class StatusReportingGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(
             // this is required to ensure status is registered properly independently 
             // of analyzer runs.
-            context.GetSponsorAdditionalFiles().Combine(context.AnalyzerConfigOptionsProvider),
+            context.GetStatusOptions(),
             (spc, source) =>
             {
-                var (manifests, options) = source;
-                var status = Diagnostics.GetOrSetStatus(manifests, options);
+                var status = Diagnostics.GetOrSetStatus(source);
                 spc.AddSource("StatusReporting.cs",
                     $"""
                     // Status: {status}
-                    // DesignTimeBuild: {options.IsDesignTimeBuild()}
+                    // DesignTimeBuild: {source.GlobalOptions.IsDesignTimeBuild()}
                     """);
                 spc.ReportDiagnostic(Diagnostic.Create("SL200", "Compiler", "Don't disable me!",
                     DiagnosticSeverity.Warning,

--- a/samples/dotnet/SponsorLink/DiagnosticsManager.cs
+++ b/samples/dotnet/SponsorLink/DiagnosticsManager.cs
@@ -70,6 +70,13 @@ class DiagnosticsManager
 
     /// <summary>
     /// Gets the status of the <see cref="Funding.Product"/>, or sets it from 
+    /// the given set of <paramref name="options"/> if not already set.
+    /// </summary>
+    public SponsorStatus GetOrSetStatus(StatusOptions options)
+        => GetOrSetStatus(() => options.AdditionalFiles, () => options.GlobalOptions);
+
+    /// <summary>
+    /// Gets the status of the <see cref="Funding.Product"/>, or sets it from 
     /// the given analyzer <paramref name="options"/> if not already set.
     /// </summary>
     public SponsorStatus GetOrSetStatus(Func<AnalyzerOptions?> options)


### PR DESCRIPTION
Specifically for incremental source generators, which are a bit more complex.

These need to run independenly from analyzers, since they are run before them, even if the latter uses CompilationStart.