### PR TITLE
If starting browser fails, render the URI to navigate to

### DIFF
--- a/src/Commands/GitHubAppAuthenticator.cs
+++ b/src/Commands/GitHubAppAuthenticator.cs
@@ -78,7 +78,14 @@ public class GitHubAppAuthenticator(IHttpClientFactory httpFactory) : IGitHubApp
         try
         {
             // Start the browser to the verification URL
-            System.Diagnostics.Process.Start(new ProcessStartInfo(auth!.verification_uri) { UseShellExecute = true });
+            try
+            {
+                System.Diagnostics.Process.Start(new ProcessStartInfo(auth!.verification_uri) { UseShellExecute = true });
+            }
+            catch (Exception)
+            {
+                progress.Report($":globe_with_meridians: Please navigate to the following page and use the code above: {auth!.verification_uri}");
+            }
 
             AuthCode? code;
             do


### PR DESCRIPTION
Users can manually navigate as a consequence and continue the flow.

This unblocks usage in WSL, for example