### PR TITLE
Allow retrieving a shields.io badge with nuget stats

### DIFF
--- a/src/Web/Stats.cs
+++ b/src/Web/Stats.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.Functions.Worker;
+using System.Net;
+using Humanizer;
+
+namespace Devlooped.Sponsors;
+
+public class Stats(AsyncLazy<OpenSource> oss, SponsorsManager manager)
+{
+    readonly TimeSpan expiration = TimeSpan.FromDays(1);
+
+    [Function("nuget-count")]
+    public async Task<HttpResponseData> NuGetCountAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "nuget/all")] HttpRequestData req)
+    {
+        var stats = await oss;
+        var manifest = await manager.GetManifestAsync();
+        var owner = req.Query.Count == 1 ? req.Query.ToString() : manifest.Sponsorable;
+
+        var count = stats.Packages
+            .Where(x => x.Key.StartsWith(owner + "/"))
+            .Sum(x => x.Value.Count);
+
+        var output = req.CreateResponse(HttpStatusCode.OK);
+
+        // Also cache downstream (specifically shields.io)
+        output.Headers.Add("Cache-Control", "public,max-age=" + expiration.TotalSeconds);
+        await output.WriteAsJsonAsync(new
+        {
+            schemaVersion = 1,
+            label = "nugets",
+            message = ((double)count).ToMetric(decimals: 1)
+        });
+
+        return output;
+    }
+
+    [Function("nuget-downloads")]
+    public async Task<HttpResponseData> NuGetDownloadsAsync([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "nuget/dl")] HttpRequestData req)
+    {
+        var stats = await oss;
+        var manifest = await manager.GetManifestAsync();
+        var owner = req.Query.Count == 1 ? req.Query.ToString() : manifest.Sponsorable;
+
+        var count = stats.Packages
+            .Where(x => x.Key.StartsWith(owner + "/"))
+            .Sum(x => x.Value.Sum(y => y.Value));
+
+        var output = req.CreateResponse(HttpStatusCode.OK);
+
+        // Also cache downstream (specifically shields.io)
+        output.Headers.Add("Cache-Control", "public,max-age=" + expiration.TotalSeconds);
+        await output.WriteAsJsonAsync(new
+        {
+            schemaVersion = 1,
+            label = "dl/day",
+            message = ((double)count).ToMetric(decimals: 1)
+        });
+
+        return output;
+    }
+
+}

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Devlooped.CredentialManager" Version="2.5.0.1" />
     <PackageReference Include="DotNetConfig.Configuration" Version="1.2.0" />
+    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />


### PR DESCRIPTION
Examples:

- https://img.shields.io/endpoint?url=https%3A%2F%2Fsponsorlink.devlooped.com%2Fnuget%2Fall%3Fkzu

- https://img.shields.io/endpoint?url=https%3A%2F%2Fsponsorlink.devlooped.com%2Fnuget%2Fdl%3Fkzu