### PR TITLE
Allow fetching specific nuget owner stats

### DIFF
--- a/src/Web/Stats.cs
+++ b/src/Web/Stats.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Azure.Functions.Worker.Http;
-using Microsoft.Azure.Functions.Worker;
-using System.Net;
+﻿using System.Net;
 using Humanizer;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
 
 namespace Devlooped.Sponsors;
 

--- a/src/Web/Webhook.cs
+++ b/src/Web/Webhook.cs
@@ -32,7 +32,7 @@ public partial class Webhook(SponsorsManager manager, SponsoredIssues issues, IC
 
         await base.ProcessSponsorshipWebhookAsync(headers, payload, action);
     }
-    
+
     protected override async Task ProcessIssueCommentWebhookAsync(WebhookHeaders headers, IssueCommentEvent payload, IssueCommentAction action)
     {
         if (await issues.UpdateBacked(github, payload.Repository?.Id, (int)payload.Issue.Number) == false)


### PR DESCRIPTION
This is useful for populating owner-specific badges without having to scrap the whole nuget.org