### PR TITLE
Add exception propagation behavior with --exceptions

### DIFF
--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -26,6 +26,12 @@ if (args.Contains("--debug"))
 var app = App.Create(out var services);
 #if DEBUG
 app.Configure(c => c.PropagateExceptions());
+#else
+if (args.Contains("--exceptions"))
+{
+    app.Configure(c => c.PropagateExceptions());
+    args = args.Where(x => x != "--exceptions").ToArray();
+}
 #endif
 
 if (args.Contains("-?"))


### PR DESCRIPTION
Useful to troubleshoot CLI execution, especially in CI.

Run the CLI passing the `--exceptions` flag and errors will be propagated up and cause the execution to stop with the full error and stacktrace. 