### PR TITLE
Add user-friendly render of nuget stats totals

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.0" />

--- a/src/Core/Records.cs
+++ b/src/Core/Records.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.ComponentModel;
+using System.Security.Cryptography;
+using Humanizer;
 
 namespace Devlooped.Sponsors;
 
@@ -37,13 +39,26 @@ public record FundedRepository(string OwnerRepo, string[] Sponsorables);
 
 public record OpenSource(ConcurrentDictionary<string, HashSet<string>> Authors, ConcurrentDictionary<string, HashSet<string>> Repositories, ConcurrentDictionary<string, ConcurrentDictionary<string, long>> Packages)
 {
-    public OpenSourceSummary Totals => new(this);
+    OpenSourceSummary? summary;
+    OpenSourceTotals? totals;
 
-    public class OpenSourceSummary(OpenSource source)
+    public OpenSourceSummary Summary => summary ??= new(Totals);
+
+    public OpenSourceTotals Totals => totals ??= new(this);
+
+    public class OpenSourceTotals(OpenSource source)
     {
-        public long Authors => source.Authors.Count;
-        public long Repositories => source.Repositories.Count;
-        public long Packages => source.Packages.Sum(x => x.Value.Count);
-        public long Downloads => source.Packages.Sum(x => x.Value.Sum(y => y.Value));
+        public double Authors => source.Authors.Count;
+        public double Repositories => source.Repositories.Count;
+        public double Packages => source.Packages.Sum(x => x.Value.Count);
+        public double Downloads => source.Packages.Sum(x => x.Value.Sum(y => y.Value));
+    }
+
+    public class OpenSourceSummary(OpenSourceTotals totals)
+    {
+        public string Authors => totals.Authors.ToMetric(decimals: 1);
+        public string Repositories => totals.Repositories.ToMetric(decimals: 1);
+        public string Packages => totals.Packages.ToMetric(decimals: 1);
+        public string Downloads => totals.Packages.ToMetric(decimals: 1);
     }
 }


### PR DESCRIPTION
This will improve rendering of dynamic badges like:

[![NuGet Packages](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgithub.com%2Fdevlooped%2Fnuget%2Fraw%2Frefs%2Fheads%2Fowners%2FDevlooped.json&query=%24.totals.packages&style=social&logo=nuget&label=packages)](https://www.nuget.org/profiles/devlooped)