### PR TITLE
Allow easily copying markdown of OSS author badges

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -120,6 +120,11 @@ issues_template: |
 
 oss_template: |
   <p class="mt-6">You contributed to the following repositories, with <strong>{{ format downloads }}</strong> combined daily downloads:</p>
+  <p>
+  <img src="https://img.shields.io/endpoint?label=popular%20packages&style=social&logo=nuget&url=https%3A%2F%2Fsponsorlink.devlooped.com%2Fnuget%2Fall?{{account}}" />
+  <img src="https://img.shields.io/endpoint?label=Daily%20downloads&style=social&logo=nuget&url=https%3A%2F%2Fsponsorlink.devlooped.com%2Fnuget%2Fdl?{{account}}" />
+  <a href="#" onclick="copyMarkdown(event)"><img src="https://img.shields.io/badge/copy-md?logo=Markdown&color=%23000000"></a>
+  </p>
   <table class="borderless" style="border-collapse: collapse; padding: 4px; min-width: unset;">
       <tr>
           <th class="borderless">Repository</th>

--- a/docs/assets/js/oss.js
+++ b/docs/assets/js/oss.js
@@ -1,3 +1,6 @@
+---
+layout: null
+---
 Handlebars.registerHelper('format', function(number) {
     return new Intl.NumberFormat().format(number);
   });
@@ -75,7 +78,7 @@ async function lookupAccount() {
             }, 0);
           }, 0);
 
-        document.getElementById('data').innerHTML = template({ repositories: repositories, downloads: totalDownloads });
+        document.getElementById('data').innerHTML = template({ account: account, icon: "{{ '/assets/img/copy.svg' | relative_url }}", repositories: repositories, downloads: totalDownloads });
         document.getElementById('unsupported').style.display = 'none';
         document.getElementById('supported').style.display = '';
 
@@ -101,4 +104,17 @@ function setError(message) {
 
 function setBusy(busy) {
     document.getElementById('spinner').style.display = busy ? '' : 'none';
+}
+
+function copyMarkdown() {
+    const url = new URL(window.location);
+    const account = url.searchParams.get('a');
+    if (account)
+    {
+        const markdown = `
+![Popular packages](https://img.shields.io/endpoint?label=popular%20packages&style=social&logo=nuget&url=https%3A%2F%2Fsponsorlink.devlooped.com%2Fnuget%2Fall?${account})
+![Daily downloads](https://img.shields.io/endpoint?label=Daily%20downloads&style=social&logo=nuget&url=https%3A%2F%2Fsponsorlink.devlooped.com%2Fnuget%2Fdl?${account})
+`;
+        navigator.clipboard.writeText(markdown);
+    }
 }


### PR DESCRIPTION
Make it very straightforward to reuse the stats in readmes and other GH pages (issues, PRs).

Stats backend is now compatible with the numbers returned by the in-memory filtering done by the OSS page too, for badge usage.