### PR TITLE
Add arbitrary yaml metadata from tier as sponsor claims

### DIFF
--- a/src/Tests/SponsorManagerTests.cs
+++ b/src/Tests/SponsorManagerTests.cs
@@ -359,5 +359,10 @@ public sealed class SponsorManagerTests : IDisposable
         Assert.True(sponsor.Tier.Meta.TryGetValue("tier", out var existing));
         Assert.Equal(tier, existing);
         Assert.Equal(type, sponsor.Kind);
+
+        var claims = await manager.GetSponsorClaimsAsync(new ClaimsPrincipal(new ClaimsIdentity([new("urn:github:login", login)], "github")));
+
+        Assert.NotNull(claims);
+        Assert.Contains(claims, claim => claim.Type == "tier" && claim.Value == tier);
     }
 }

--- a/src/Web/Stats.cs
+++ b/src/Web/Stats.cs
@@ -19,7 +19,7 @@ public class Stats(AsyncLazy<OpenSource> oss, SponsorsManager manager)
         if (req.Query.Count == 1)
         {
             // Sum all packages across all repositories contributed to by the author in the querystring
-            if (req.Query.ToString() is { } author && 
+            if (req.Query.ToString() is { } author &&
                 stats.Authors.TryGetValue(author, out var repositories))
             {
                 count = stats.Packages


### PR DESCRIPTION
As part of the tier description, sponsorables can add arbitrary yaml metadata such as:

```
<!-- tier: basic -->
```

Multiple values are supported in standard yaml format.

These claims are cumulative (i.e. tier 3 gets tier 2 and tier 1 metadata, with the closest tier to the actual sponsoring tier wins).

This now allows client code to selectively enable functionality based on GH sponsorship tier metadata.

Fixes #234