### PR TITLE
Use stable hash comparer for nuget/oss model

### DIFF
--- a/src/Core/FnvHashComparer.cs
+++ b/src/Core/FnvHashComparer.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Devlooped.Sponsors;
+
+public class FnvHashComparer : IEqualityComparer<string>
+{
+    // FNV-1a 32 bit prime and offset basis
+    const uint FnvPrime = 0x01000193;
+    const uint FnvOffsetBasis = 0x811C9DC5;
+
+    public static IEqualityComparer<string> Default { get; } = new FnvHashComparer();
+
+    public bool Equals(string? x, string? y)
+    {
+        // If both are null, or both are same instance, consider them equal
+        if (x == y) return true;
+        if (x == null || y == null) return false;
+        return x.Equals(y, StringComparison.Ordinal); // Use Ordinal for performance
+    }
+
+    public int GetHashCode(string obj)
+    {
+        // Convert the 32-bit unsigned hash to a signed int for .NET's GetHashCode
+        return unchecked((int)Fnv1aHash(obj));
+    }
+
+    // Method to compute FNV-1a hash for a string
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static uint Fnv1aHash(string str)
+    {
+        var hash = FnvOffsetBasis;
+        foreach (var c in str)
+        {
+            hash ^= c; // XOR the character
+            hash *= FnvPrime; // Multiply by the FNV prime
+        }
+        return hash;
+    }
+}

--- a/src/Core/Records.cs
+++ b/src/Core/Records.cs
@@ -42,6 +42,10 @@ public record OpenSource(ConcurrentDictionary<string, HashSet<string>> Authors, 
     OpenSourceSummary? summary;
     OpenSourceTotals? totals;
 
+    public OpenSource() : this(new(FnvHashComparer.Default), new(FnvHashComparer.Default), new(FnvHashComparer.Default))
+    {            
+    }
+
     public OpenSourceSummary Summary => summary ??= new(Totals);
 
     public OpenSourceTotals Totals => totals ??= new(this);


### PR DESCRIPTION
This makes it eaiser to merge PRs when stats are run/updated, since otherwise keys move around since the hashes aren't really stable OOB.