### PR TITLE
When auth fails during nuget stats, render failure

### DIFF
--- a/src/Commands/GitHub.cs
+++ b/src/Commands/GitHub.cs
@@ -116,6 +116,10 @@ public static class GitHub
             if (!TryExecute("gh", $"auth login --with-token", token, out var output))
             {
                 Debug.Fail(output);
+                AnsiConsole.MarkupLine("[red]Failed to authenticate with provided token[/]");
+                if (output.Trim().Length > 0)
+                    AnsiConsole.MarkupLine($"[dim]{output.Trim()}[/]");
+
                 return null;
             }
 

--- a/src/Commands/Process.cs
+++ b/src/Commands/Process.cs
@@ -52,6 +52,8 @@ public static class Process
             output = output.Trim();
             if (string.IsNullOrEmpty(output))
                 output = null;
+            if (output == null && gotError && !string.IsNullOrWhiteSpace(error))
+                output = error.Trim();
 
             return !gotError && proc.ExitCode == 0;
         }


### PR DESCRIPTION
It can be helpful to see the actual error from the GH CLI when authentication fails. We only propagate the error as the output to the caller from our process helper if there was no output already (i.e. some graphql APIs return failure but still provide data). This eliminates the chance of breaking existing code that relied on that.

Also added a debug-only option to pass in a direct token, which is easier for debug runs of the CLI.