### PR TITLE
Account for source repo name/ownership changes for nuget stats

### DIFF
--- a/src/Core/GraphQueries.cs
+++ b/src/Core/GraphQueries.cs
@@ -887,6 +887,14 @@ public static partial class GraphQueries
     };
 
     /// <summary>
+    /// Gets the current full name of the specified owner/repo (might have been renamed and/or moved to another owner).
+    /// </summary>
+    public static GraphQuery<string> RepositoryFullName(string ownerRepo) => new($"/repos/{ownerRepo}", ".full_name")
+    {
+        IsLegacy = true,
+    };
+
+    /// <summary>
     /// Gets rate limit information.
     /// </summary>
     public static GraphQuery<Rate> RateLimits => new(


### PR DESCRIPTION
Packages may have specified a certain owner/repo information, which can later be changed on github. Repositories can be renamed, and ownership transferred, which would now leave an inconsistency in how we report since the current info on github wouldn't match a published package.

We account for this by first resolving the full name of the owner/repo we find in package metadata, which would account for any renaming that happened.