### PR TITLE
Allow customizing the sponsorables for sync from a derived command

### DIFF
--- a/src/Cli/sync.md
+++ b/src/Cli/sync.md
@@ -12,11 +12,11 @@ OPTIONS:
     -h, --help          Prints help information                                 
         --autosync      Enable or disable automatic synchronization of expired  
                         manifests                                               
-    -l, --local         Sync only existing local manifests                      
     -f, --force         Force sync, regardless of expiration of manifests found 
                         locally                                                 
     -v, --validate      Validate local manifests using the issuer public key    
     -u, --unattended    Prevent interactive credentials refresh                 
         --with-token    Read GitHub authentication token from standard input for
                         sync                                                    
+    -l, --local         Sync only existing local manifests                      
 ```

--- a/src/Commands/Properties/Resources.resx
+++ b/src/Commands/Properties/Resources.resx
@@ -338,4 +338,7 @@ Code for the backend and this app are [link=https://www.devlooped.com/SponsorLin
   <data name="FirstRun_TelemetryTitle" xml:space="preserve">
     <value>Telemetry</value>
   </data>
+  <data name="Sync_LocalNotFound" xml:space="preserve">
+    <value>No local manifests found for --local sync.</value>
+  </data>
 </root>

--- a/src/Tests/RemoveCommandTests.cs
+++ b/src/Tests/RemoveCommandTests.cs
@@ -28,7 +28,7 @@ public class RemoveCommandTests
             new GitHubAppAuthenticator(Services.GetRequiredService<IHttpClientFactory>()),
             Services.GetRequiredService<IHttpClientFactory>());
 
-        var result = await command.ExecuteAsync(new CommandContext(["sync"], Mock.Of<IRemainingArguments>(), "sync", null), new SyncCommand.SyncSettings
+        var result = await command.ExecuteAsync(new CommandContext(["sync"], Mock.Of<IRemainingArguments>(), "sync", null), new SyncCommand.SponsorableSyncSettings
         {
             Sponsorable = ["devlooped"],
             // NOTE: would only succeed if we hav previously sync'ed at least once with the devlooped gh app

--- a/src/Tests/SyncCommandTests.cs
+++ b/src/Tests/SyncCommandTests.cs
@@ -30,7 +30,7 @@ public class SyncCommandTests
             Mock.Of<IGitHubAppAuthenticator>(MockBehavior.Strict),
             Mock.Of<IHttpClientFactory>(MockBehavior.Strict));
 
-        var settings = new SyncCommand.SyncSettings
+        var settings = new SyncCommand.SponsorableSyncSettings
         {
             Unattended = true,
         };
@@ -56,7 +56,7 @@ public class SyncCommandTests
             Mock.Of<IGitHubAppAuthenticator>(MockBehavior.Strict),
             Mock.Of<IHttpClientFactory>(MockBehavior.Strict));
 
-        var settings = new SyncCommand.SyncSettings
+        var settings = new SyncCommand.SponsorableSyncSettings
         {
             Unattended = true,
         };
@@ -82,7 +82,7 @@ public class SyncCommandTests
             auth.Object,
             Services.GetRequiredService<IHttpClientFactory>());
 
-        var settings = new SyncCommand.SyncSettings
+        var settings = new SyncCommand.SponsorableSyncSettings
         {
             Sponsorable = ["kzu"],
             Unattended = true,
@@ -104,7 +104,7 @@ public class SyncCommandTests
             Mock.Of<IGitHubAppAuthenticator>(MockBehavior.Strict),
             Services.GetRequiredService<IHttpClientFactory>());
 
-        var settings = new SyncCommand.SyncSettings
+        var settings = new SyncCommand.SponsorableSyncSettings
         {
             Sponsorable = ["devlooped-bot"],
             Unattended = true,
@@ -130,7 +130,7 @@ public class SyncCommandTests
             new GitHubAppAuthenticator(Services.GetRequiredService<IHttpClientFactory>()),
             Services.GetRequiredService<IHttpClientFactory>());
 
-        var settings = new SyncCommand.SyncSettings
+        var settings = new SyncCommand.SponsorableSyncSettings
         {
             Sponsorable = ["devlooped"],
             // NOTE: requires prior running of the `sponsor sync --namespace nonsponsoring` command for interactive auth.


### PR DESCRIPTION
This can be used by a CLI for example to provide its own version of the sync command that hardcodes the accounts to sync.