### PR TITLE
Move ThisAssembly to Devlooped.Sponsors namespace

### DIFF
--- a/src/Commands/Commands.csproj
+++ b/src/Commands/Commands.csproj
@@ -7,6 +7,8 @@
     <Product>SponsorLink</Product>
     <Description>Commands used by the dotnet-sponsor CLI to manage sponsorship manifests.</Description>
     <PackageId>Devlooped.Sponsors.Commands</PackageId>
+    <ThisAssemblyNamespace>Devlooped.Sponsors</ThisAssemblyNamespace>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Commands/ConfigCommand.cs
+++ b/src/Commands/ConfigCommand.cs
@@ -3,7 +3,7 @@ using DotNetConfig;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using static Spectre.Console.AnsiConsole;
-using static ThisAssembly;
+using static Devlooped.Sponsors.ThisAssembly;
 
 namespace Devlooped.Sponsors;
 

--- a/src/Commands/RemoveCommand.cs
+++ b/src/Commands/RemoveCommand.cs
@@ -4,7 +4,7 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using static Spectre.Console.AnsiConsole;
-using static ThisAssembly.Strings;
+using static Devlooped.Sponsors.ThisAssembly.Strings;
 
 namespace Devlooped.Sponsors;
 

--- a/src/Commands/SyncCommand.cs
+++ b/src/Commands/SyncCommand.cs
@@ -10,7 +10,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using static Devlooped.Sponsors.SyncCommand;
 using static Spectre.Console.AnsiConsole;
-using static ThisAssembly.Strings;
+using static Devlooped.Sponsors.ThisAssembly.Strings;
 
 namespace Devlooped.Sponsors;
 

--- a/src/Commands/ThisAssembly.cs
+++ b/src/Commands/ThisAssembly.cs
@@ -1,4 +1,6 @@
-﻿[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1050:Declare types in namespaces")]
+﻿namespace Devlooped.Sponsors;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1050:Declare types in namespaces")]
 public partial class ThisAssembly
 {
 }

--- a/src/Commands/ViewCommand.cs
+++ b/src/Commands/ViewCommand.cs
@@ -7,7 +7,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using static Devlooped.Sponsors.ViewCommand;
 using static Spectre.Console.AnsiConsole;
-using static ThisAssembly;
+using static Devlooped.Sponsors.ThisAssembly;
 
 namespace Devlooped.Sponsors;
 


### PR DESCRIPTION
This avoids colliding with consuming projects.