### PR TITLE
Don't make the type registrar public

### DIFF
--- a/src/Commands/TypeRegistrar.cs
+++ b/src/Commands/TypeRegistrar.cs
@@ -3,7 +3,7 @@ using Spectre.Console.Cli;
 
 namespace Devlooped.Sponsors;
 
-public sealed class TypeRegistrar(IServiceCollection? builder = default) : ITypeRegistrar
+sealed class TypeRegistrar(IServiceCollection? builder = default) : ITypeRegistrar
 {
     readonly IServiceCollection builder = builder ?? new ServiceCollection();
 


### PR DESCRIPTION
We have different versions of it and it's confusing.