### PR TITLE
Rename fecher to avoid confusion with manifest itself

### DIFF
--- a/src/Commands/SyncCommand.cs
+++ b/src/Commands/SyncCommand.cs
@@ -330,8 +330,8 @@ public abstract class SyncCommand<TSettings>(DotNetConfig.Config config, IGraphQ
             }
 
             using var http = httpFactory.CreateClient();
-            var (status, jwt) = await Status().StartAsync(Sync.Synchronizing(manifest.Sponsorable), async ctx => await SponsorManifest.FetchAsync(manifest, token, http));
-            if (status == SponsorManifest.Status.NotSponsoring)
+            var (status, jwt) = await Status().StartAsync(Sync.Synchronizing(manifest.Sponsorable), async ctx => await SponsorManifestFetcher.FetchAsync(manifest, token, http));
+            if (status == SponsorManifestFetcher.Status.NotSponsoring)
             {
                 var links = string.Join(", ", manifest.Audience.Select(x => $"[link]{x}[/]"));
                 MarkupLine(Sync.ConsiderSponsoring(manifest.Sponsorable.PadRight(maxlength), links));
@@ -339,7 +339,7 @@ public abstract class SyncCommand<TSettings>(DotNetConfig.Config config, IGraphQ
                 continue;
             }
 
-            if (status == SponsorManifest.Status.Success)
+            if (status == SponsorManifestFetcher.Status.Success)
             {
                 File.WriteAllText(Path.Combine(ghDir, manifest.Sponsorable + ".jwt"), jwt, Encoding.UTF8);
                 var roles = new JsonWebTokenHandler
@@ -373,14 +373,14 @@ public abstract class SyncCommand<TSettings>(DotNetConfig.Config config, IGraphQ
                         return;
 
                     using var http = httpFactory.CreateClient();
-                    var (status, jwt) = await SponsorManifest.FetchAsync(manifest, token, http);
-                    if (status == SponsorManifest.Status.NotSponsoring)
+                    var (status, jwt) = await SponsorManifestFetcher.FetchAsync(manifest, token, http);
+                    if (status == SponsorManifestFetcher.Status.NotSponsoring)
                     {
                         var links = string.Join(", ", manifest.Audience.Select(x => $"[link]{x}[/]"));
                         MarkupLine(Sync.ConsiderSponsoring(manifest.Sponsorable.PadRight(maxlength), links));
                         result = ErrorCodes.NotSponsoring;
                     }
-                    else if (status == SponsorManifest.Status.Success)
+                    else if (status == SponsorManifestFetcher.Status.Success)
                     {
                         File.WriteAllText(Path.Combine(ghDir, manifest.Sponsorable + ".jwt"), jwt);
                         var roles = new JsonWebTokenHandler()

--- a/src/Core/SponsorManifestFetcher.cs
+++ b/src/Core/SponsorManifestFetcher.cs
@@ -6,7 +6,7 @@ namespace Devlooped.Sponsors;
 /// <summary>
 /// Allows synchronizing client sponsor manifests.
 /// </summary>
-public class SponsorManifest
+public class SponsorManifestFetcher
 {
     /// <summary>
     /// Status of a manifest refresh operation.
@@ -30,10 +30,10 @@ public class SponsorManifest
     /// <summary>
     /// Refreshes the sponsor manifest for the given sponsorable account.
     /// </summary>
-    /// <param name="accessToken">The access token to use for fetching the manifest, must be an OAuth token issued by GitHub for the sponsorable app..</param>
+    /// <param name="accessToken">The access token to use for fetching the manifest, must be an OAuth token issued by GitHub for the sponsorable app, representing the sponsoring user.</param>
     /// <param name="manifest">The SponsorLink manifest provided by the sponsorable account.</param>
     /// <param name="jwt">The sponsor manifest token, if sponsoring.</param>
-    /// <returns>The status of the manifest synchronization.</returns>
+    /// <returns>The status of the manifest synchronization and the optional JWT of the authenticated user if validation succeeded.</returns>
     public static async Task<(Status, string?)> FetchAsync(SponsorableManifest manifest, string accessToken, HttpClient? http = default)
     {
         var disposeHttp = http == null;


### PR DESCRIPTION
This class is used to fetch the authenticated user's JWT claims for syncing. It does not represent the manifest itself, which is something the SL samples showcase how to turn into a proper class if needed.

The JWT can be read by any standards-compatible lib.