### PR TITLE
Mention active sponsors in releases

### DIFF
--- a/src/Web/EnumerableExtensions.cs
+++ b/src/Web/EnumerableExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Devlooped.Sponsors;
+
+public static class EnumerableExtensions
+{
+    /// <summary>
+    /// Batches the source sequence into chunks of the specified size.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in the source sequence.</typeparam>
+    /// <param name="source">The source sequence to batch.</param>
+    /// <param name="size">The maximum size of each batch. Must be greater than 0.</param>
+    /// <returns>An IEnumerable of IEnumerables, each representing a batch of elements.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if source is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if size is less than or equal to 0.</exception>
+    public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> source, int size)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+        if (size <= 0)
+            throw new ArgumentOutOfRangeException(nameof(size), "Size must be greater than 0.");
+
+        return BatchIterator(source, size);
+    }
+
+    static IEnumerable<IEnumerable<T>> BatchIterator<T>(IEnumerable<T> source, int size)
+    {
+        var batch = new List<T>(size);
+        foreach (var item in source)
+        {
+            batch.Add(item);
+            if (batch.Count == size)
+            {
+                yield return batch;
+                batch = new List<T>(size);
+            }
+        }
+        if (batch.Count > 0)
+        {
+            yield return batch;
+        }
+    }
+}

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -6,16 +6,19 @@
     <Product>SponsorLink</Product>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="local.settings.json" />
+  </ItemGroup>
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Devlooped.CredentialManager" Version="2.6.1" />
     <PackageReference Include="DotNetConfig.Configuration" Version="1.2.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
@@ -28,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.0.14" PrivateAssets="all" />
     <PackageReference Include="CliWrap" Version="3.8.2" />
-    <PackageReference Include="Octokit.Webhooks.AzureFunctions" Version="2.4.1" />
+    <PackageReference Include="Octokit.Webhooks.AzureFunctions" Version="3.2.1" />
     <PackageReference Include="ThisAssembly.Constants" Version="2.0.14" PrivateAssets="all" />
     <PackageReference Include="YamlPeek" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
GitHub will auto-generate a Contributors section with the profile pics of all mentioned accounts.

This will trigger the notification to all sponsors, which should be enough visibility.

See for example https://github.com/devlooped/dotnet-retest/releases/tag/v1.0.0

Also allow skipping the sponsors section entirely by adding `<!-- nosponsors -->` anywhere in the body.