### PR TITLE
⬆️ Bump files with dotnet-file sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
     Web:
       patterns:
         - "Microsoft.AspNetCore*"
+    OpenTelemetry:
+      patterns:
+        - "OpenTelemetry*"
     Tests:
       patterns:
         - "Microsoft.NET.Test*"

--- a/.github/workflows/includes.yml
+++ b/.github/workflows/includes.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   includes:
     runs-on: ubuntu-latest
+    env:
+      PR_TOKEN: ${{ secrets.DEVLOOPED_TOKEN || secrets.GH_TOKEN }}
     permissions:
       contents: write
       pull-requests: write
@@ -21,16 +23,16 @@ jobs:
         with:
           name: ${{ secrets.BOT_NAME }}
           email: ${{ secrets.BOT_EMAIL }}
-          gh_token: ${{ secrets.GH_TOKEN }}
+          gh_token: ${{ env.PR_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🤘 checkout
         uses: actions/checkout@v4
         with: 
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN || github.token }}
 
       - name: +Mᐁ includes
-        uses: devlooped/actions-includes@v1
+        uses: devlooped/actions-includes@v2
 
       - name: 📝 OSMF EULA
         shell: pwsh
@@ -50,18 +52,24 @@ jobs:
           ((get-content -raw $file) -replace '\$product\$',$product).trim() | set-content $file
 
       - name: ✍ pull request
-        uses: peter-evans/create-pull-request@v6
+        if: env.PR_TOKEN != ''
+        uses: peter-evans/create-pull-request@v8
         with:
           add-paths: |
             **.md
-            osmfeula.txt
+            *.txt
           base: main
           branch: markdown-includes
           delete-branch: true
-          labels: docs
+          labels: dependencies
           author: ${{ env.BOT_AUTHOR }}
           committer: ${{ env.BOT_AUTHOR }}
           commit-message: +Mᐁ includes
           title: +Mᐁ includes
           body: +Mᐁ includes
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.PR_TOKEN }}
+
+      - name: ⚠️ skip pull request
+        if: env.PR_TOKEN == ''
+        shell: bash
+        run: echo "::warning::Skipping PR creation because neither DEVLOOPED_TOKEN nor GH_TOKEN is configured. GITHUB_TOKEN cannot create pull requests in this repository."

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,24 @@
 bin
 obj
+out
 artifacts
 pack
+agent-tools
+terminals
 TestResults
 results
 BenchmarkDotNet.Artifacts
+mcps
 /app
+/temp
 .vs
 .vscode
 .genaiscript
 .idea
 local.settings.json
 .env
+.next
+*.local
 
 *.suo
 *.sdf
@@ -25,6 +32,7 @@ local.settings.json
 *.binlog
 *.zip
 __azurite*.*
+AzuriteConfig
 __*__
 
 .nuget

--- a/.netconfig
+++ b/.netconfig
@@ -5,8 +5,8 @@
 	weak
 [file ".gitignore"]
 	url = https://github.com/devlooped/oss/blob/main/.gitignore
-	sha = 3776526342afb3f57da7e80f2095e5fdca3c31c9
-	etag = 11767f73556aa4c6c8bcc153b77ee8e8114f99fa3b885b0a7d66d082f91e77b3
+	sha = ff61659751374b95c7a8a0477c908a8119f756f0
+	etag = e5865f083db45081a7b4eaa518018971b34e6ef93f917ac510dea96d27f792b3
 	weak
 [file ".gitattributes"]
 	url = https://github.com/devlooped/oss/blob/main/.gitattributes
@@ -25,23 +25,23 @@
 	weak
 [file ".github/workflows/includes.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/includes.yml
-	sha = 26e8cb798ce72dec7072db826cc9694d456797bd
-	etag = df06492eeb2daaae4168d71bbb643f5da2693b67cdd58c42ffa44a191ee99b69
+	sha = d571412f07b0fb3c40023dc906f64906d7ed2b46
+	etag = ab627107749577bb619b024aff93027359b66b4c3f5a85a36b235e428387cd17
 	weak
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = c509be4378ff6789df4f66338cb88119453c0975
-	etag = cbbdc1a4d3030f353f3e5306a6c380238dd4ed0945aad2d56ba87b49fcfcd66d
+	sha = 6e2438919e108aeb75106dc0737c45f5e55d5f42
+	etag = f1d6384abf18d8d891ce5e835a10c73fe029c42151374be96d7e4af43d189c65
 	weak
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 4339749ef4b8f66def75931df09ef99c149f8421
-	etag = 8b4492765755c030c4c351e058a92f53ab493cab440c1c0ef431f6635c4dae0e
+	sha = dcd5f0a9a00a5b0c23d41a71dcc66ea41dc5f75d
+	etag = 2cca66d8a1adbae24dc2efee53a55fa09949242eb35b86c5fd66425da18c6107
 	weak
 [file ".github/dependabot.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/dependabot.yml
-	sha = e733294084fb3e75d517a2e961e87df8faae7dc6
-	etag = 3bf8d9214a15c049ca5cfe80d212a8cbe4753b8a638a9804ef73d34c7def9618
+	sha = 387f0616b2c56adc4f33f2858da818f7e0d92ef3
+	etag = a1aaba1440e5ee2a7b7f93fc0fb004d4e1d4d9780350c753f7c429e37241345a
 	weak
 [file ".github/workflows/changelog.config"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/changelog.config
@@ -111,3 +111,30 @@
 	sha = 0c23e24704625cf75b2cb1fdc566cef7e20af313
 	etag = 310df162242c95ed19ed12e3c96a65f77e558b46dced676ad5255eb12caafe75
 	weak
+[file ".netconfig"]
+	url = https://github.com/devlooped/oss/blob/main/.netconfig
+	skip
+[file "readme.md"]
+	url = https://github.com/devlooped/oss/blob/main/readme.md
+	skip
+[file "readme.tmp.md"]
+	url = https://github.com/devlooped/oss/blob/main/readme.tmp.md
+	skip
+[file "oss.cs"]
+	url = https://github.com/devlooped/oss/blob/main/oss.cs
+	skip
+[file "Directory.Build.rsp"]
+	url = https://github.com/devlooped/oss/blob/main/Directory.Build.rsp
+	skip
+[file "src/kzu.snk"]
+	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
+	skip
+[file ".github/workflows/combine-prs.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/combine-prs.yml
+	skip
+[file ".github/workflows/dotnet-file-core.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file-core.yml
+	skip
+[file ".github/actions/dotnet/action.yml"]
+	url = https://github.com/devlooped/oss/blob/main/.github/actions/dotnet/action.yml
+	skip

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project>
+<Project TreatAsLocalProperty="VersionPrefix">
   <!-- To extend/change the defaults, create a Directory.props alongside this file -->
 
   <PropertyGroup Label="CI" Condition="'$(CI)' == ''">
@@ -43,6 +43,13 @@
 
     <!-- Ensure MSBuild tooling can access package artifacts always via PKG_[PackageId] -->
     <GeneratePathProperty>true</GeneratePathProperty>
+    <!-- Avoid warnings for test projects when we run dotnet pack on the whole solution. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <!-- See https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#prunepackagereference-specification -->
+    <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
+
+    <!-- Needed to improve nuget default for empty PackageId. Workaround for https://github.com/NuGet/Home/issues/14928 -->
+    <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
   </PropertyGroup>
 
   <PropertyGroup Label="Build">
@@ -134,6 +141,15 @@
     <VersionSuffix Condition="!$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</VersionSuffix>
     <!-- Special case for tags, the label is actually the version. Backs compat since passed-in value overrides MSBuild-set one -->
     <Version Condition="$(VersionLabel.Contains('refs/tags/'))">$(_VersionLabel)</Version>
+
+    <!-- In order for latest from main/master to always be greatest when using -prerelease switch on install/run, 
+         we change the scheme as follows:
+         - main/master remain as today: VersionPrefix: 42.42.${{ github.run_number }}  (from yaml)
+         - others: VersionPrefix: 42.42.0-[label].${{ github.run_number }}
+    -->
+    <IsMaster Condition="$(VersionLabel.Contains('refs/heads/main')) or $(VersionLabel.Contains('refs/heads/master'))">true</IsMaster>
+    <VersionPrefix Condition="'$(IsMaster)' != 'true'">42.42.0</VersionPrefix>
+    <VersionSuffix Condition="'$(IsMaster)' != 'true'">$(VersionSuffix).$(GITHUB_RUN_NUMBER)</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup Label="ThisAssembly.Project">
@@ -151,6 +167,10 @@
     <Using Include="System.ArgumentException" Static="true" />
     <Using Include="System.ArgumentOutOfRangeException" Static="true" />
     <Using Include="System.ArgumentNullException" Static="true" />
+  </ItemGroup>
+
+  <ItemGroup Label="OSMF" Condition="Exists('$(MSBuildThisFileDirectory)..\osmfeula.txt')">
+    <Content Include="$(MSBuildThisFileDirectory)..\osmfeula.txt" Link="osmfeula.txt" Pack="true" PackagePath="OSMFEULA.txt" Visible="false" />
   </ItemGroup>
 
   <Import Project="Directory.props" Condition="Exists('Directory.props')"/>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -32,6 +32,22 @@
     <IsPackable Condition="'$(PackageId)' != ''">true</IsPackable>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <!-- Save original PackageId to restore post-import -->
+    <_PackageId>$(PackageId)</_PackageId>
+    <!-- Since we set ImportNuGetBuildTasksPackTargetsFromSdk=false, the Sdk.targets doesn't even provide the path for this property :/ -->
+    <NuGetBuildTasksPackTargets Condition="'$(NuGetBuildTasksPackTargets)' == ''">$(MSBuildSDKsPath)\..\NuGet.Build.Tasks.Pack.targets</NuGetBuildTasksPackTargets>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetBuildTasksPackTargets)" Condition="Exists('$(NuGetBuildTasksPackTargets)') And '$(NuGetize)' != 'true'" />
+
+  <PropertyGroup>
+    <!-- Revert the forced PackageId by the NuGet SDK targets for non-packable projects, see https://github.com/NuGet/Home/issues/14928 -->
+    <PackageId Condition="'$(IsPackable)' == 'false'">$(_PackageId)</PackageId>
+    <!-- If no PackageId was originally provided, ensure IsPackable is false -->
+    <IsPackable Condition="'$(_PackageId)' == ''">false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsPackable)' == 'true'" Label="NuGet">
     <!-- This is compatible with nugetizer and SDK pack -->
     <!-- Only difference is we don't copy either to output directory -->
@@ -174,7 +190,7 @@
 
   <Target Name="UpdatePackageMetadata"
           BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFileShouldRun;GetAssemblyVersion;GetPackageMetadata;GenerateNuspec;Pack"
-          DependsOnTargets="EnsureProjectInformation"
+          DependsOnTargets="EnsureProjectInformation;UpdatePackageLicense"
           Condition="'$(SourceControlInformationFeatureSupported)' == 'true' And
                      '$(IsPackable)' == 'true'">
     <PropertyGroup>
@@ -183,6 +199,16 @@
       <PackageReleaseNotes Condition="'$(RepositoryUrl)' != '' and Exists('$(MSBuildThisFileDirectory)..\changelog.md')">$(RepositoryUrl.Replace('.git', ''))/blob/main/changelog.md</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
+
+  <Target Name="UpdatePackageLicense">
+    <!-- If project has a None/Content item with PackagePath=OSMFEULA.txt -->
+    <PropertyGroup Condition="@(None -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != '' or @(Content -> WithMetadataValue('PackagePath', 'OSMFEULA.txt')) != ''">
+      <PackageLicenseExpression></PackageLicenseExpression>
+      <PackageLicenseFile>OSMFEULA.txt</PackageLicenseFile>
+      <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    </PropertyGroup>
+  </Target>
+
 
   <!-- Import before UsingTask because first to declare tasks wins -->
   <Import Project="Directory.targets" Condition="Exists('Directory.targets')"/>


### PR DESCRIPTION
# devlooped/oss

- Disable warnings for non-packable test projects https://github.com/devlooped/oss/commit/95b338b
- Update versioning scheme in Directory.Build.props https://github.com/devlooped/oss/commit/f2400ef
- Enable package pruning in Directory.Build.props https://github.com/devlooped/oss/commit/0ff8b7b
- Ignore *.local recursively https://github.com/devlooped/oss/commit/a225b7a
- If the OSMF eula is present, switch to its license file https://github.com/devlooped/oss/commit/4b84c54
- Change file type from None to Content for osmfeula.txt https://github.com/devlooped/oss/commit/fd03672
- Add Pack attribute to OSMFEULA content item https://github.com/devlooped/oss/commit/dd13ed3
- Consider either None or Content for OSMF license patching https://github.com/devlooped/oss/commit/083a37b
- Add AzuriteConfig to .gitignore https://github.com/devlooped/oss/commit/12c18e7
- Hide osmfeula.txt from package visibility https://github.com/devlooped/oss/commit/a1f5d11
- Add OpenTelemetry patterns to dependabot config https://github.com/devlooped/oss/commit/387f061
- Add new entries to .gitignore file https://github.com/devlooped/oss/commit/c76f0cc
- Fix PackageId default from Pack SDK https://github.com/devlooped/oss/commit/6e24389
- Improve PackageId/IsPackable defaulting https://github.com/devlooped/oss/commit/e8b0802
- Add '/mcps' to .gitignore https://github.com/devlooped/oss/commit/c1d29fb
- Fix empty default path for NuGet SDK targets https://github.com/devlooped/oss/commit/c679525
- Add '/temp' directory to .gitignore https://github.com/devlooped/oss/commit/79631d3
- Update .gitignore to ignore 'mcps' folder recursively https://github.com/devlooped/oss/commit/11680ae
- Add 'terminals' to .gitignore https://github.com/devlooped/oss/commit/5e7a79e
- Add 'agent-tools' to .gitignore https://github.com/devlooped/oss/commit/ff61659
- fix: support robust NuGetize pack delegation for PackFolder=build projects (#39) https://github.com/devlooped/oss/commit/dcd5f0a
- Change label from 'docs' to 'dependencies' https://github.com/devlooped/oss/commit/2d1fb4e
- Avoid failure on PR creation if osmfeula.txt doesn't exist in repo https://github.com/devlooped/oss/commit/8ff5178
- Update create-pull-request action to version 8 https://github.com/devlooped/oss/commit/0662872
- Refactor GitHub Actions workflows to use unified PR_TOKEN for authentication and add skip PR creation warning https://github.com/devlooped/oss/commit/7c1c6e6
- Update actions-includes version to v2 https://github.com/devlooped/oss/commit/d571412